### PR TITLE
Support for placeholders for output filename prefixes in configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
 - <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(object)*: The main configuration body.
   - **`output_dir`** *(string, required)*: Directory for the output of the sampled audio files.
   - **`processed_output_dir`** *(string, required)*: Directory for the output of processed sampled audio files.
-  - **`output_prefix`** *(string)*: Prefix for the filenames of the sampled audio files. Default: `""`.
+  - **`output_prefix_format`** *(string)*: Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {note}, {velocity}. Default: `"{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}"`.
   - **`pre_send_smf_path_list`** *(array)*: These file(s) will be sent to the MIDI device before sampling once e.g. GM Reset, CC Reset, etc. Default: `[]`.
     - **Items** *(string)*: Path to the SMF(*.mid/*.midi) file(s).
   - **`midi_channel`** *(integer, required)*: MIDI channel number for sampling. Minimum: `0`. Maximum: `15`.
@@ -178,7 +178,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   {
       "output_dir": "_recorded",
       "processed_output_dir": "_recorded/_processed",
-      "output_prefix": "output",
+      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}",
       "pre_send_smf_path_list": [
           "path/to/GM_Reset.mid",
           "path/to/CC_Init.mid"

--- a/README_ja.md
+++ b/README_ja.md
@@ -163,7 +163,7 @@ python -m midisampling.device
 - <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(object)*: 主な設定構成。
   - **`output_dir`** *(string, required)*: サンプリングされた音声ファイルの出力ディレクトリ。
   - **`processed_output_dir`** *(string, required)*: 処理済みのサンプリング音声ファイルの出力ディレクトリ。
-  - **`output_prefix`** *(string)*: サンプリングされた音声ファイルのファイル名のプレフィックス。デフォルト: `""`。
+  - **`output_prefix_format`** *(文字列)*: サンプリングした音声ファイルのファイル名の接頭辞。このプレースホルダが使用可能: {pc_msb}, {pc_lsb}, {pc}, {note}, {velocity}。デフォルト: `"{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}"`.
   - **`pre_send_smf_path_list`** *(array)*: サンプリングの前にMIDIデバイスに送信されるファイル（例: GMリセット、CCリセットなど）。デフォルト: `[]`。
     - **Items** *(string)*: SMF(*.mid/*.midi)ファイルのパス。
   - **`midi_channel`** *(integer, required)*: サンプリング用のMIDIチャンネル番号。最小: `0`。最大: `15`。
@@ -183,7 +183,7 @@ python -m midisampling.device
   {
       "output_dir": "_recorded",
       "processed_output_dir": "_recorded/_processed",
-      "output_prefix": "output",
+      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}",
       "pre_send_smf_path_list": [
           "path/to/GM_Reset.mid",
           "path/to/CC_Init.mid"

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -1,7 +1,7 @@
 {
     "output_dir": "_recorded",
     "processed_output_dir": "_recorded/_processed",
-    "output_prefix": "",
+    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}",
     "pre_send_smf_path_list": [
         "GS_Reset.mid",
         "Reverb_Chorus_Delay_Set_0.mid"

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -16,10 +16,10 @@
                     "type": "string",
                     "description": "Directory for the output of processed sampled audio files."
                 },
-                "output_prefix": {
+                "output_prefix_format": {
                     "type": "string",
-                    "description": "Prefix for the filenames of the sampled audio files.",
-                    "default": ""
+                    "description": "Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {note}, {velocity}.",
+                    "default": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}"
                 },
                 "pre_send_smf_path_list" : {
                     "type":"array",
@@ -101,7 +101,7 @@
                 {
                     "output_dir": "_recorded",
                     "processed_output_dir": "_recorded/_processed",
-                    "output_prefix": "output",
+                    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}",
                     "pre_send_smf_path_list": [
                         "path/to/GM_Reset.mid",
                         "path/to/CC_Init.mid"

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -100,7 +100,7 @@ class MidiConfig:
         self.config_dir: str                                        = os.path.abspath(os.path.dirname(config_path))
         self.output_dir: str                                        = config_json["output_dir"]
         self.processed_output_dir: str                              = config_json["processed_output_dir"]
-        self.output_prefix: str                                     = config_json["output_prefix"]
+        self.output_prefix_format: str                              = config_json["output_prefix_format"]
         self.pre_send_smf_path_list: List[str]                      = config_json["pre_send_smf_path_list"]
         self.midi_channel: int                                      = config_json["midi_channel"]
         self.program_change_list: List[MidiConfig.ProgramChange]    = []

--- a/midisampling/dynamic_format.py
+++ b/midisampling/dynamic_format.py
@@ -1,0 +1,32 @@
+import re
+
+def format(format_string:str, data:dict):
+    """
+    Generates a string in the specified format using a format string and a data dictionary.
+
+    This function extracts placeholder keys from the specified format string,
+    applies the format by filtering only those keys that are present in the data dictionary.
+    Even if a format specifier is included, it will be handled correctly.
+
+    Arguments:: string
+        format_string (str): The format specifier string. For example, “{key1}-{key2:08d}”.
+        data (dict): A dictionary containing data to be used for formatting. Keys in the dictionary must correspond to
+                     placeholders in the format string.
+
+    Returns: str: the formatted string
+        str: The formatted string.
+
+    Example usage: str: formatted string.
+        format_string = “{pc}-{note:08d}”
+        data = {“pc”: 1, “note”: 123}
+        result = format(format_string, data)
+        print(result) # Output: '1-00000123'
+    """
+
+    # Extract only key names other than format specifiers
+    keys_in_format  = re.findall(r'{(\w+)', format_string)
+
+    # Make a dictionary with only the keys that are in the format string
+    filtered = {key: data[key] for key in keys_in_format if key in data}
+
+    return format_string.format(**filtered)

--- a/midisampling/utility.py
+++ b/midisampling/utility.py
@@ -1,4 +1,0 @@
-import json
-
-def as_json_structure(obj: object) -> None:
-    return json.dumps(obj.__dict__, ensure_ascii=False, indent=2)


### PR DESCRIPTION
Scripts that were hard-coded with format strings can now be written in configuration files.