### PR TITLE
Feature/sample zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,25 +155,22 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
 
 #### Definitions
 
-- <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(object)*: The main configuration body.
+- <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(object)*: The main configuration body. Cannot contain additional properties.
   - **`output_dir`** *(string, required)*: Directory for the output of the sampled audio files.
   - **`processed_output_dir`** *(string, required)*: Directory for the output of processed sampled audio files.
-  - **`output_prefix_format`** *(string)*: Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {note}, {min_velocity} {max_velocity} {velocity}. Default: `"{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}"`.
+  - **`output_prefix_format`** *(string)*: Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {min_velocity} {max_velocity} {velocity}. Default: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`.
   - **`pre_send_smf_path_list`** *(array)*: These file(s) will be sent to the MIDI device before sampling once e.g. GM Reset, CC Reset, etc. Default: `[]`.
     - **Items** *(string)*: Path to the SMF(*.mid/*.midi) file(s).
   - **`midi_channel`** *(integer, required)*: MIDI channel number for sampling. Minimum: `0`. Maximum: `15`.
   - **`midi_program_change_list`** *(array, required)*: List of MIDI program change (MSB, LSB, Program No) for sampling.
-    - **Items** *(object)*
+    - **Items** *(object)*: Cannot contain additional properties.
       - **`msb`** *(integer)*: MSB value for the MIDI program change. Minimum: `0`. Maximum: `127`.
       - **`lsb`** *(integer)*: LSB value for the MIDI program change. Minimum: `0`. Maximum: `127`.
       - **`program`** *(integer)*: Program number for the MIDI program change. Minimum: `0`. Maximum: `127`.
-  - **`midi_notes`** *(array, required)*: List of MIDI note numbers to be sampled.
-    - **Items**
-      - **Any of**
-        - : MIDI note number. Refer to *[#/definitions/def_midi_message_byte](#definitions/def_midi_message_byte)*.
-        - : MIDI note range. Refer to *[#/definitions/def_midi_message_byte_range](#definitions/def_midi_message_byte_range)*.
-  - **`midi_velocity_layers`** *(array, required)*: List of velocity layers to be sampled.
-    - **Items**: Refer to *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*.
+  - **`sample_zone_complex`** *(array)*: List of keymaps for the sampled MIDI notes.
+    - **Items**: Refer to *[#/definitions/def_sample_zone_complex](#definitions/def_sample_zone_complex)*.
+  - **`sample_zone`** *(array)*: List of keymaps for the sampled MIDI notes.
+    - **Items**: Refer to *[#/definitions/def_sample_zone](#definitions/def_sample_zone)*.
   - **`midi_pre_wait_duration`** *(number, required)*: Pre-wait time (in seconds) before sampling. A value of `0.6` or higher is recommended.
   - **`midi_note_duration`** *(integer, required)*: Length of the MIDI note to be sampled (in seconds). Only integer values can be specified.
   - **`midi_release_duration`** *(number, required)*: Wait time (in seconds) after the release of the sampled MIDI note. Only integer values can be specified.
@@ -183,7 +180,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   {
       "output_dir": "_recorded",
       "processed_output_dir": "_recorded/_processed",
-      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}",
+      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
       "pre_send_smf_path_list": [
           "path/to/GM_Reset.mid",
           "path/to/CC_Init.mid"
@@ -206,24 +203,34 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
               "program": 2
           }
       ],
-      "midi_velocity_layers": [
+      "sample_zone": [
           {
-              "min": 0,
-              "max": 63,
-              "send": 63
-          },
-          {
-              "min": 64,
-              "max": 127,
-              "send": 127
+              "key_root": {
+                  "from": 40,
+                  "to": 41
+              },
+              "velocity_layers": [
+                  {
+                      "min": 0,
+                      "max": 63,
+                      "send": 63
+                  }
+              ]
           }
       ],
-      "midi_notes": [
+      "sample_zone_complex": [
           {
-              "from": 40,
-              "to": 43
-          },
-          80
+              "key_low": 0,
+              "key_high": 0,
+              "key_root": 40,
+              "velocity_layers": [
+                  {
+                      "min": 0,
+                      "max": 63,
+                      "send": 63
+                  }
+              ]
+          }
       ],
       "midi_pre_wait_duration": 0.6,
       "midi_note_duration": 2,
@@ -232,9 +239,9 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   ```
 
 - <a id="definitions/def_midi_message_byte"></a>**`def_midi_message_byte`** *(integer)*: Represents the value of the MIDI message byte (0-127). Minimum: `0`. Maximum: `127`.
-- <a id="definitions/def_integer_range"></a>**`def_integer_range`** *(object)*: Represents an integer value range.
-  - **`from`** *(integer)*
-  - **`to`** *(integer)*
+- <a id="definitions/def_integer_range"></a>**`def_integer_range`** *(object)*: Represents an integer value range. Cannot contain additional properties.
+  - **`from`** *(integer, required)*
+  - **`to`** *(integer, required)*
 
   Examples:
   ```json
@@ -244,7 +251,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   }
   ```
 
-- <a id="definitions/def_midi_message_byte_range"></a>**`def_midi_message_byte_range`** *(object)*: Represents the value range (0-127) of the MIDI message byte.
+- <a id="definitions/def_midi_message_byte_range"></a>**`def_midi_message_byte_range`** *(object)*: Represents the value range (0-127) of the MIDI message byte. Cannot contain additional properties.
   - **`from`**: Refer to *[#/definitions/def_midi_message_byte](#definitions/def_midi_message_byte)*.
   - **`to`**: Refer to *[#/definitions/def_midi_message_byte](#definitions/def_midi_message_byte)*.
 
@@ -256,7 +263,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   }
   ```
 
-- <a id="definitions/def_midivelocity_layer"></a>**`def_midivelocity_layer`** *(object)*: Velocity layer configuration.
+- <a id="definitions/def_midivelocity_layer"></a>**`def_midivelocity_layer`** *(object)*: Velocity layer configuration. Cannot contain additional properties.
   - **`min`** *(integer, required)*: Minimum velocity value. Minimum: `0`. Maximum: `127`.
   - **`max`** *(integer, required)*: Maximum velocity value. Minimum: `0`. Maximum: `127`.
   - **`send`** *(integer, required)*: Velocity value actually sent to the MIDI device when sampling. Minimum: `0`. Maximum: `127`.
@@ -267,6 +274,83 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
       "min": 0,
       "max": 127,
       "send": 127
+  }
+  ```
+
+- <a id="definitions/def_sample_zone_complex"></a>**`def_sample_zone_complex`** *(object)*: Sample zone complex configuration. The key range, root key, must be specified explicitly. Cannot contain additional properties.
+  - **`key_low`** *(integer, required)*: Lowest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software. Minimum: `0`. Maximum: `127`.
+  - **`key_high`** *(integer, required)*: Highest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software. Minimum: `0`. Maximum: `127`.
+  - **`key_root`** *(integer, required)*: Root key number (note number) in the keymap. This value is intended to be used as information for mapping note-on messages sent to MIDI devices and third-party sampler software when sampling. Minimum: `0`. Maximum: `127`.
+  - **`velocity_layers`** *(array, required)*
+    - **Items**:
+        - : Refer to *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*.
+
+  Examples:
+  ```json
+  {
+      "key_low": 0,
+      "key_high": 32,
+      "key_root": 16,
+      "velocity_layers": [
+          {
+              "min": 0,
+              "max": 31,
+              "send": 31
+          },
+          {
+              "min": 32,
+              "max": 63,
+              "send": 63
+          },
+          {
+              "min": 64,
+              "max": 95,
+              "send": 95
+          },
+          {
+              "min": 96,
+              "max": 127,
+              "send": 127
+          }
+      ]
+  }
+  ```
+
+- <a id="definitions/def_sample_zone"></a>**`def_sample_zone`** *(object)*: A simple configuration of sample zone. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`. Cannot contain additional properties.
+  - **`keys`**: Root key number (note number) in the keymap. Refer to *[#/definitions/def_midi_message_byte_range](#definitions/def_midi_message_byte_range)*.
+  - **`velocity_layers`** *(array, required)*
+    - **Items**:
+        - : Refer to *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*.
+
+  Examples:
+  ```json
+  {
+      "keys": {
+          "from": 10,
+          "to": 100
+      },
+      "velocity_layers": [
+          {
+              "min": 0,
+              "max": 31,
+              "send": 31
+          },
+          {
+              "min": 32,
+              "max": 63,
+              "send": 63
+          },
+          {
+              "min": 64,
+              "max": 95,
+              "send": 95
+          },
+          {
+              "min": 96,
+              "max": 127,
+              "send": 127
+          }
+      ]
   }
   ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -154,41 +154,38 @@ python -m midisampling.device
   }
   ```
 
-### MIDIサンプリング設定
+### MIDIサンプリング構成
 
-*MIDIサンプリング設定の構成。*
+*MIDIサンプリング構成の構造。*
 
 #### 定義
 
-- <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(object)*: 主な設定構成。
-  - **`output_dir`** *(string, required)*: サンプリングされた音声ファイルの出力ディレクトリ。
-  - **`processed_output_dir`** *(string, required)*: 処理済みのサンプリング音声ファイルの出力ディレクトリ。
-  - **`output_prefix_format`** *(文字列)*: サンプリングした音声ファイルのファイル名の接頭辞。このプレースホルダが使用可能: {pc_msb}, {pc_lsb}, {pc}, {note}, {min_velocity} {max_velocity} {velocity}。デフォルト: `"{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}"`。
-  - **`pre_send_smf_path_list`** *(array)*: サンプリングの前にMIDIデバイスに送信されるファイル（例: GMリセット、CCリセットなど）。デフォルト: `[]`。
-    - **Items** *(string)*: SMF(*.mid/*.midi)ファイルのパス。
-  - **`midi_channel`** *(integer, required)*: サンプリング用のMIDIチャンネル番号。最小: `0`。最大: `15`。
-  - **`midi_program_change_list`** *(array, required)*: サンプリング用のMIDIプログラムチェンジ（MSB、LSB、プログラム番号）のリスト。
-    - **Items** *(object)*
-      - **`msb`** *(integer)*: MIDIプログラムチェンジのMSB値。最小: `0`。最大: `127`。
-      - **`lsb`** *(integer)*: MIDIプログラムチェンジのLSB値。最小: `0`。最大: `127`。
-      - **`program`** *(integer)*: MIDIプログラムチェンジのプログラム番号。最小: `0`。最大: `127`。
-  - **`midi_notes`** *(array, required)*: サンプリングするMIDIノート番号のリスト。
-    - **項目**
-      - **以下のいずれか**
-        - : MIDIノート番号。*[#/definitions/def_midi_message_byte](#definitions/def_midi_message_byte)*を参照。
-        - : MIDIノート範囲。*[#/definitions/def_midi_message_byte_range](#definitions/def_midi_message_byte_range)*を参照。
-  - **`midi_velocity_layers`** *(配列, 必須)*: サンプリングするベロシティレイヤーのリスト。
-    - **アイテム**: *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)* を参照。
-  - **`midi_pre_wait_duration`** *(number, required)*: サンプリング前の待機時間（秒単位）。`0.6`秒以上が推奨される。
-  - **`midi_note_duration`** *(integer, required)*: サンプリングするMIDIノートの長さ（秒単位）。整数値のみ指定可能。
-  - **`midi_release_duration`** *(number, required)*: サンプリングされたMIDIノートのリリース後の待機時間（秒単位）。整数値のみ指定可能。
+- <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(オブジェクト)*: メイン構成本体。追加のプロパティは含めることができません。
+  - **`output_dir`** *(文字列, 必須)*: サンプリングされたオーディオファイルの出力先ディレクトリ。
+  - **`processed_output_dir`** *(文字列, 必須)*: 処理されたサンプリングオーディオファイルの出力先ディレクトリ。
+  - **`output_prefix_format`** *(文字列)*: サンプリングされたオーディオファイルのファイル名の接頭辞。このプレースホルダーが使用できます: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {min_velocity} {max_velocity} {velocity}。デフォルト: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`。
+  - **`pre_send_smf_path_list`** *(配列)*: サンプリングの前にMIDIデバイスに送信されるファイル（例：GMリセット、CCリセットなど）。デフォルト: `[]`。
+    - **アイテム** *(文字列)*: SMF(*.mid/*.midi)ファイルへのパス。
+  - **`midi_channel`** *(整数, 必須)*: サンプリング用のMIDIチャンネル番号。最小: `0`。最大: `15`。
+  - **`midi_program_change_list`** *(配列, 必須)*: サンプリング用のMIDIプログラムチェンジ(MSB, LSB, Program No)のリスト。
+    - **アイテム** *(オブジェクト)*: 追加のプロパティは含めることができません。
+      - **`msb`** *(整数)*: MIDIプログラムチェンジのMSB値。最小: `0`。最大: `127`。
+      - **`lsb`** *(整数)*: MIDIプログラムチェンジのLSB値。最小: `0`。最大: `127`。
+      - **`program`** *(整数)*: MIDIプログラムチェンジのプログラム番号。最小: `0`。最大: `127`。
+  - **`sample_zone_complex`** *(配列)*: サンプリングされたMIDIノートのキー・マッピングのリスト。
+    - **アイテム**: *[#/definitions/def_sample_zone_complex](#definitions/def_sample_zone_complex)*を参照。
+  - **`sample_zone`** *(配列)*: サンプリングされたMIDIノートのキー・マッピングのリスト。
+    - **アイテム**: *[#/definitions/def_sample_zone](#definitions/def_sample_zone)*を参照。
+  - **`midi_pre_wait_duration`** *(数値, 必須)*: サンプリング前の待機時間（秒単位）。`0.6`秒以上が推奨されます。
+  - **`midi_note_duration`** *(整数, 必須)*: サンプリングされるMIDIノートの長さ（秒単位）。整数値のみ指定可能です。
+  - **`midi_release_duration`** *(数値, 必須)*: サンプリングされたMIDIノートのリリース後の待機時間（秒単位）。整数値のみ指定可能です。
 
   例:
   ```json
   {
       "output_dir": "_recorded",
       "processed_output_dir": "_recorded/_processed",
-      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}",
+      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
       "pre_send_smf_path_list": [
           "path/to/GM_Reset.mid",
           "path/to/CC_Init.mid"
@@ -211,24 +208,34 @@ python -m midisampling.device
               "program": 2
           }
       ],
-      "midi_velocity_layers": [
+      "sample_zone": [
           {
-              "min": 0,
-              "max": 63,
-              "send": 63
-          },
-          {
-              "min": 64,
-              "max": 127,
-              "send": 127
+              "key_root": {
+                  "from": 40,
+                  "to": 41
+              },
+              "velocity_layers": [
+                  {
+                      "min": 0,
+                      "max": 63,
+                      "send": 63
+                  }
+              ]
           }
       ],
-      "midi_notes": [
+      "sample_zone_complex": [
           {
-              "from": 40,
-              "to": 43
-          },
-          80
+              "key_low": 0,
+              "key_high": 0,
+              "key_root": 40,
+              "velocity_layers": [
+                  {
+                      "min": 0,
+                      "max": 63,
+                      "send": 63
+                  }
+              ]
+          }
       ],
       "midi_pre_wait_duration": 0.6,
       "midi_note_duration": 2,
@@ -236,10 +243,10 @@ python -m midisampling.device
   }
   ```
 
-- <a id="definitions/def_midi_message_byte"></a>**`def_midi_message_byte`** *(integer)*: MIDIメッセージバイトの値を表す（0-127）。最小値: `0`。最大値: `127`。
-- <a id="definitions/def_integer_range"></a>**`def_integer_range`** *(object)*: 整数値の範囲を表す。
-  - **`from`** *(integer)*
-  - **`to`** *(integer)*
+- <a id="definitions/def_midi_message_byte"></a>**`def_midi_message_byte`** *(整数)*: MIDIメッセージバイトの値(0-127)を表します。最小: `0`。最大: `127`。
+- <a id="definitions/def_integer_range"></a>**`def_integer_range`** *(オブジェクト)*: 整数値の範囲を表します。追加のプロパティは含めることができません。
+  - **`from`** *(整数, 必須)*
+  - **`to`** *(整数, 必須)*
 
   例:
   ```json
@@ -249,7 +256,7 @@ python -m midisampling.device
   }
   ```
 
-- <a id="definitions/def_midi_message_byte_range"></a>**`def_midi_message_byte_range`** *(object)*: MIDIメッセージバイトの値の範囲（0-127）を表す。
+- <a id="definitions/def_midi_message_byte_range"></a>**`def_midi_message_byte_range`** *(オブジェクト)*: MIDIメッセージバイトの値範囲(0-127)を表します。追加のプロパティは含めることができません。
   - **`from`**: *[#/definitions/def_midi_message_byte](#definitions/def_midi_message_byte)*を参照。
   - **`to`**: *[#/definitions/def_midi_message_byte](#definitions/def_midi_message_byte)*を参照。
 
@@ -261,10 +268,10 @@ python -m midisampling.device
   }
   ```
 
-- <a id="definitions/def_midivelocity_layer"></a>**`def_midivelocity_layer`** *(オブジェクト)*: ベロシティレイヤー設定。
-  - **`min`** *(整数, 必須)*: 最小ベロシティ値。最小値: `0`。最大値: `127`。
-  - **`max`** *(整数, 必須)*: 最大ベロシティ値。最小値: `0`。最大値: `127`。
-  - **`send`** *(整数, 必須)*: サンプリング時にMIDIデバイスに送信されるベロシティ値。最小値: `0`。最大値: `127`。
+- <a id="definitions/def_midivelocity_layer"></a>**`def_midivelocity_layer`** *(オブジェクト)*: ベロシティレイヤーの設定。追加のプロパティは含めることができません。
+  - **`min`** *(整数, 必須)*: 最小ベロシティ値。最小: `0`。最大: `127`。
+  - **`max`** *(整数, 必須)*: 最大ベロシティ値。最小: `0`。最大: `127`。
+  - **`send`** *(整数, 必須)*: サンプリング時にMIDIデバイスに送信されるベロシティ値。最小: `0`。最大: `127`。
 
   例:
   ```json
@@ -272,6 +279,85 @@ python -m midisampling.device
       "min": 0,
       "max": 127,
       "send": 127
+  }
+  ```
+
+- <a id="definitions/def_sample_zone_complex"></a>**`def_sample_zone_complex`** *(オブジェクト)*: 複雑なサンプルゾーン設定。キー範囲とルートキーを明示的に指定する必要があります。追加のプロパティは含めることができません。
+  - **`key_low`** *(整数, 必須)*: キーマップ内の最低キー番号（ノート番号）。この値は、サードパーティのサンプラーソフトウェアとのマッピング情報として使用されることを意図しています。最小: `0`。最大: `127`。
+  - **`key_high`** *(整数, 必須)*: キーマップ内の最高キー番号（ノート番号）。この値は、サードパーティのサンプラーソフトウェアとのマッピング情報として使用されることを意図しています。最小: `0`。最大: `127`。
+  - **`key_root`** *(整数, 必須)*: キーマップのルートキー番号（ノート番号）。この値は、サンプリング時にMIDIデバイスやサードパーティのサンプラーソフトウェアに送信されるノートオンメッセージの情報として使用されることを意図しています。最小: `0`。最大: `127`。
+  - **`velocity_layers`** *(配列, 必
+
+須)*
+    - **アイテム**:
+        - : *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*を参照。
+
+  例:
+  ```json
+  {
+      "key_low": 0,
+      "key_high": 32,
+      "key_root": 16,
+      "velocity_layers": [
+          {
+              "min": 0,
+              "max": 31,
+              "send": 31
+          },
+          {
+              "min": 32,
+              "max": 63,
+              "send": 63
+          },
+          {
+              "min": 64,
+              "max": 95,
+              "send": 95
+          },
+          {
+              "min": 96,
+              "max": 127,
+              "send": 127
+          }
+      ]
+  }
+  ```
+
+- <a id="definitions/def_sample_zone"></a>**`def_sample_zone`** *(オブジェクト)*: シンプルなサンプルゾーン設定。複雑なバージョンとは異なり、`ルートキー`だけを指定でき、個々の`key_range`の値が`ルートキー`、`最低キー`、`最高キー`として適用されます。追加のプロパティは含めることができません。
+  - **`keys`**: キーマップのルートキー番号（ノート番号）。*[#/definitions/def_midi_message_byte_range](#definitions/def_midi_message_byte_range)*を参照。
+  - **`velocity_layers`** *(配列, 必須)*
+    - **アイテム**:
+        - : *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*を参照。
+
+  例:
+  ```json
+  {
+      "keys": {
+          "from": 10,
+          "to": 100
+      },
+      "velocity_layers": [
+          {
+              "min": 0,
+              "max": 31,
+              "send": 31
+          },
+          {
+              "min": 32,
+              "max": 63,
+              "send": 63
+          },
+          {
+              "min": 64,
+              "max": 95,
+              "send": 95
+          },
+          {
+              "min": 96,
+              "max": 127,
+              "send": 127
+          }
+      ]
   }
   ```
 

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -12,27 +12,12 @@
     ],
     "midi_keymaps": [
         {
-            "key_root": {"from": 40, "to": 41},
+            "key_root": {"from": 40, "to": 40},
             "velocity_layers": [
-                {
-                    "min": 0,
-                    "max": 63,
-                    "send": 63
-                }
-            ]
-        }
-    ],
-    "midi_keymaps_complex": [
-        {
-            "key_low": 0,
-            "key_high": 0,
-            "key_root": 40,
-            "velocity_layers": [
-                {
-                    "min": 0,
-                    "max": 63,
-                    "send": 63
-                }
+                {"min": 0,  "max": 31,  "send": 31},
+                {"min": 32, "max": 63,  "send": 63},
+                {"min": 64, "max": 95,  "send": 95},
+                {"min": 96, "max": 127, "send": 127}
             ]
         }
     ],

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -10,21 +10,6 @@
     "midi_program_change_list": [
         { "msb": 0, "lsb": 0, "program": 48}
     ],
-    "midi_velocity_layers": [
-        {
-            "min": 0,
-            "max": 63,
-            "send": 63
-        },
-        {
-            "min": 64,
-            "max": 127,
-            "send": 127
-        }
-    ],
-    "midi_notes": [
-        { "from": 40, "to": 41 }, 90
-    ],
     "midi_keymaps": [
         {
             "key_root": {"from": 40, "to": 41},

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -10,9 +10,22 @@
     "midi_program_change_list": [
         { "msb": 0, "lsb": 0, "program": 48}
     ],
-    "midi_keymaps": [
+    "sample_zone_complex": [
         {
-            "key_root": {"from": 40, "to": 40},
+            "key_low": 0,
+            "key_high": 32,
+            "key_root": 16,
+            "velocity_layers": [
+                { "min": 0,  "max": 31,  "send": 31 },
+                { "min": 32, "max": 63,  "send": 63 },
+                { "min": 64, "max": 95,  "send": 95 },
+                { "min": 96, "max": 127, "send": 127 }
+            ]
+        }
+    ],
+    "sample_zone": [
+        {
+            "keys": {"from": 40, "to": 40},
             "velocity_layers": [
                 {"min": 0,  "max": 31,  "send": 31},
                 {"min": 32, "max": 63,  "send": 63},

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -1,7 +1,7 @@
 {
     "output_dir": "_recorded",
     "processed_output_dir": "_recorded/_processed",
-    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{note}_{min_velocity}_{max_velocity}_{velocity}",
+    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{key_low}_{key_high}_{velocity}_{min_velocity}_{max_velocity}",
     "pre_send_smf_path_list": [
         "GS_Reset.mid",
         "Reverb_Chorus_Delay_Set_0.mid"
@@ -25,7 +25,7 @@
     "midi_notes": [
         { "from": 40, "to": 41 }, 90
     ],
-    "midi_keymap_simple": [
+    "midi_keymaps": [
         {
             "key_root": {"from": 40, "to": 41},
             "velocity_layers": [
@@ -37,7 +37,7 @@
             ]
         }
     ],
-    "midi_keymap_complex": [
+    "midi_keymaps_complex": [
         {
             "key_low": 0,
             "key_high": 0,

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -25,6 +25,32 @@
     "midi_notes": [
         { "from": 40, "to": 41 }, 90
     ],
+    "midi_keymap_simple": [
+        {
+            "key_root": {"from": 40, "to": 41},
+            "velocity_layers": [
+                {
+                    "min": 0,
+                    "max": 63,
+                    "send": 63
+                }
+            ]
+        }
+    ],
+    "midi_keymap_complex": [
+        {
+            "key_low": 0,
+            "key_high": 0,
+            "key_root": 40,
+            "velocity_layers": [
+                {
+                    "min": 0,
+                    "max": 63,
+                    "send": 63
+                }
+            ]
+        }
+    ],
     "midi_pre_wait_duration": 0.6,
     "midi_note_duration": 2,
     "midi_release_duration": 1.5

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -2,10 +2,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MIDI Sampling Configuration",
     "description": "Structure of the MIDI sampling configuration.",
-    "additionalProperties": false,
     "definitions": {
         "def_midi_config": {
             "type": "object",
+            "additionalProperties": false,
             "description": "The main configuration body",
             "properties": {
                 "output_dir": {
@@ -41,6 +41,7 @@
                     "description": "List of MIDI program change (MSB, LSB, Program No) for sampling.",
                     "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "msb": {
                                 "type": "integer",
@@ -155,6 +156,7 @@
         },
         "def_integer_range": {
             "type": "object",
+            "additionalProperties": false,
             "description": "Represents an integer value range",
             "properties": {
                 "from": {
@@ -164,12 +166,17 @@
                     "type": "integer"
                 }
             },
+            "required": [
+                "from",
+                "to"
+            ],
             "examples": [
                 { "from": 10, "to": 100 }
             ]
         },
         "def_midi_message_byte_range": {
             "type": "object",
+            "additionalProperties": false,
             "description": "Represents the value range (0-127) of the MIDI message byte",
             "properties": {
                 "from": {
@@ -179,12 +186,17 @@
                     "$ref": "#/definitions/def_midi_message_byte"
                 }
             },
+            "required": [
+                "from",
+                "to"
+            ],
             "examples": [
                 { "from": 10, "to": 100 }
             ]
         },
         "def_midivelocity_layer": {
             "type": "object",
+            "additionalProperties": false,
             "description": "Velocity layer configuration",
             "properties": {
                 "min": {
@@ -221,5 +233,6 @@
         }
     },
     "type": "object",
+    "additionalProperties": false,
     "$ref": "#/definitions/def_midi_config"
 }

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -64,18 +64,18 @@
                         }
                     }
                 },
-                "midi_keymaps_complex" :{
+                "sample_zone_complex" :{
                     "type":"array",
                     "description": "List of keymaps for the sampled MIDI notes.",
                     "items": {
-                        "$ref": "#/definitions/def_keymap_complex"
+                        "$ref": "#/definitions/def_sample_zone_complex"
                     }
                 },
-                "midi_keymaps" :{
+                "sample_zone" :{
                     "type":"array",
                     "description": "List of keymaps for the sampled MIDI notes.",
                     "items": {
-                        "$ref": "#/definitions/def_midi_keymap_simple"
+                        "$ref": "#/definitions/def_sample_zone"
                     }
                 },
                 "midi_pre_wait_duration": {
@@ -115,7 +115,7 @@
                         { "msb": 0, "lsb": 0, "program": 1},
                         { "msb": 0, "lsb": 0, "program": 2}
                     ],
-                    "midi_keymaps": [
+                    "sample_zone": [
                         {
                             "key_root": {"from": 40, "to": 41},
                             "velocity_layers": [
@@ -127,7 +127,7 @@
                             ]
                         }
                     ],
-                    "midi_keymaps_complex": [
+                    "sample_zone_complex": [
                         {
                             "key_low": 0,
                             "key_high": 0,
@@ -230,10 +230,10 @@
                 }
             ]
         },
-        "def_keymap_complex": {
+        "def_sample_zone_complex": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Keymap complex configuration. The key range, root key, must be specified explicitly.",
+            "description": "Sample zone complex configuration. The key range, root key, must be specified explicitly.",
             "properties": {
                 "key_low": {
                     "type": "integer",
@@ -282,10 +282,10 @@
                 }
             ]
         },
-        "def_midi_keymap_simple": {
+        "def_sample_zone": {
             "type": "object",
             "additionalProperties": false,
-            "description": "A simple configuration of the keymap. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`.",
+            "description": "A simple configuration of sample zone. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`.",
             "properties": {
                 "keys": {
                     "description": "Root key number (note number) in the keymap.",

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -18,8 +18,8 @@
                 },
                 "output_prefix_format": {
                     "type": "string",
-                    "description": "Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {note}, {min_velocity} {max_velocity} {velocity}.",
-                    "default": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}"
+                    "description": "Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {min_velocity} {max_velocity} {velocity}.",
+                    "default": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"
                 },
                 "pre_send_smf_path_list" : {
                     "type":"array",
@@ -64,30 +64,6 @@
                         }
                     }
                 },
-                "midi_notes": {
-                    "type": "array",
-                    "description": "List of MIDI note numbers to be sampled.",
-                    "items": {
-                        "anyOf": [
-                            {
-                                "description": "MIDI note number.",
-                                "$ref": "#/definitions/def_midi_message_byte"
-                            },
-                            {
-                                "description": "MIDI note range.",
-                                "$ref": "#/definitions/def_midi_message_byte_range"
-                            }
-                        ]
-                    }
-                },
-                "midi_velocity_layers": {
-                    "type": "array",
-                    "description": "List of velocity layers to be sampled.",
-
-                    "items": {
-                        "$ref": "#/definitions/def_midivelocity_layer"
-                    }
-                },
                 "midi_keymaps_complex" :{
                     "type":"array",
                     "description": "List of keymaps for the sampled MIDI notes.",
@@ -120,8 +96,6 @@
                 "processed_output_dir",
                 "midi_channel",
                 "midi_program_change_list",
-                "midi_velocity_layers",
-                "midi_notes",
                 "midi_pre_wait_duration",
                 "midi_note_duration",
                 "midi_release_duration"
@@ -130,7 +104,7 @@
                 {
                     "output_dir": "_recorded",
                     "processed_output_dir": "_recorded/_processed",
-                    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{note}_{velocity}",
+                    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
                     "pre_send_smf_path_list": [
                         "path/to/GM_Reset.mid",
                         "path/to/CC_Init.mid"
@@ -141,20 +115,31 @@
                         { "msb": 0, "lsb": 0, "program": 1},
                         { "msb": 0, "lsb": 0, "program": 2}
                     ],
-                    "midi_velocity_layers": [
+                    "midi_keymaps": [
                         {
-                            "min": 0,
-                            "max": 63,
-                            "send": 63
-                        },
-                        {
-                            "min": 64,
-                            "max": 127,
-                            "send": 127
+                            "key_root": {"from": 40, "to": 41},
+                            "velocity_layers": [
+                                {
+                                    "min": 0,
+                                    "max": 63,
+                                    "send": 63
+                                }
+                            ]
                         }
                     ],
-                    "midi_notes" : [
-                        { "from": 40, "to": 43 }, 80
+                    "midi_keymaps_complex": [
+                        {
+                            "key_low": 0,
+                            "key_high": 0,
+                            "key_root": 40,
+                            "velocity_layers": [
+                                {
+                                    "min": 0,
+                                    "max": 63,
+                                    "send": 63
+                                }
+                            ]
+                        }
                     ],
                     "midi_pre_wait_duration": 0.6,
                     "midi_note_duration": 2,

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -88,14 +88,14 @@
                         "$ref": "#/definitions/def_midivelocity_layer"
                     }
                 },
-                "midi_keymap_complex" :{
+                "midi_keymaps_complex" :{
                     "type":"array",
                     "description": "List of keymaps for the sampled MIDI notes.",
                     "items": {
                         "$ref": "#/definitions/def_keymap_complex"
                     }
                 },
-                "midi_keymap_simple" :{
+                "midi_keymaps" :{
                     "type":"array",
                     "description": "List of keymaps for the sampled MIDI notes.",
                     "items": {

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -88,6 +88,20 @@
                         "$ref": "#/definitions/def_midivelocity_layer"
                     }
                 },
+                "midi_keymap_complex" :{
+                    "type":"array",
+                    "description": "List of keymaps for the sampled MIDI notes.",
+                    "items": {
+                        "$ref": "#/definitions/def_keymap_complex"
+                    }
+                },
+                "midi_keymap_simple" :{
+                    "type":"array",
+                    "description": "List of keymaps for the sampled MIDI notes.",
+                    "items": {
+                        "$ref": "#/definitions/def_midi_keymap_simple"
+                    }
+                },
                 "midi_pre_wait_duration": {
                     "type": "number",
                     "description": "Pre-wait time (in seconds) before sampling. A value of `0.6` or higher is recommended."
@@ -228,6 +242,91 @@
                     "min": 0,
                     "max": 127,
                     "send": 127
+                }
+            ]
+        },
+        "def_keymap_complex": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Keymap complex configuration. The key range, root key, must be specified explicitly.",
+            "properties": {
+                "key_low": {
+                    "type": "integer",
+                    "description": "Lowest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
+                    "minimum": 0,
+                    "maximum": 127
+                },
+                "key_high": {
+                    "type": "integer",
+                    "description": "Highest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
+                    "minimum": 0,
+                    "maximum": 127
+                },
+                "key_root": {
+                    "type": "integer",
+                    "description": "Root key number (note number) in the keymap. This value is intended to be used as information for mapping note-on messages sent to MIDI devices and third-party sampler software when sampling.",
+                    "minimum": 0,
+                    "maximum": 127
+                },
+                "velocity_layers": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "$ref": "#/definitions/def_midivelocity_layer"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "key_low",
+                "key_high",
+                "key_root",
+                "velocity_layers"
+            ],
+            "examples": [
+                {
+                    "key_low": 0,
+                    "key_high": 32,
+                    "key_root": 16
+                }
+            ]
+        },
+        "def_midi_keymap_simple": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Keymap simple configuration. Unlike the complex version, only the root key can be specified, where `key range` = `root key`.",
+            "properties": {
+                "key_root": {
+                    "description": "Root key number (note number) in the keymap.",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/def_midi_message_byte"
+                        },
+                        {
+                            "$ref": "#/definitions/def_midi_message_byte_range"
+                        }
+                    ],
+                    "examples": [
+                        16,
+                        { "from": 10, "to": 100 }
+                    ]
+                },
+                "velocity_layers": {
+                    "type": "array",
+                    "items":[
+                        {
+                            "$ref": "#/definitions/def_midivelocity_layer"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "key_root",
+                "velocity_layers"
+            ],
+            "examples": [
+                {
+                    "key_roots": [16]
                 }
             ]
         }

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -272,29 +272,24 @@
                 {
                     "key_low": 0,
                     "key_high": 32,
-                    "key_root": 16
+                    "key_root": 16,
+                    "velocity_layers": [
+                        { "min": 0,  "max": 31,  "send": 31 },
+                        { "min": 32, "max": 63,  "send": 63 },
+                        { "min": 64, "max": 95,  "send": 95 },
+                        { "min": 96, "max": 127, "send": 127 }
+                    ]
                 }
             ]
         },
         "def_midi_keymap_simple": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Keymap simple configuration. Unlike the complex version, only the root key can be specified, where `key range` = `root key`.",
+            "description": "A simple configuration of the keymap. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`.",
             "properties": {
-                "key_root": {
+                "keys": {
                     "description": "Root key number (note number) in the keymap.",
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/def_midi_message_byte"
-                        },
-                        {
-                            "$ref": "#/definitions/def_midi_message_byte_range"
-                        }
-                    ],
-                    "examples": [
-                        16,
-                        { "from": 10, "to": 100 }
-                    ]
+                    "$ref": "#/definitions/def_midi_message_byte_range"
                 },
                 "velocity_layers": {
                     "type": "array",
@@ -306,12 +301,18 @@
                 }
             },
             "required": [
-                "key_root",
+                "keys",
                 "velocity_layers"
             ],
             "examples": [
                 {
-                    "key_roots": [16]
+                    "keys": { "from": 10, "to": 100 },
+                    "velocity_layers": [
+                        { "min": 0,  "max": 31,  "send": 31 },
+                        { "min": 32, "max": 63,  "send": 63 },
+                        { "min": 64, "max": 95,  "send": 95 },
+                        { "min": 96, "max": 127, "send": 127 }
+                    ]
                 }
             ]
         }

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -129,7 +129,26 @@ class KeyMapUnit:
         """
         Create KeyMapUnit list from json data (keymap_complex)
         """
-        return []
+        result: List['KeyMapUnit'] = []
+
+        for key in keymap_complex:
+            key_root = key["key_root"]
+            key_low  = key["key_low"]
+            key_high = key["key_high"]
+
+            velocity_layers: List[VelocityLayer] = []
+
+            for x in key["velocity_layers"]:
+                velocity_layers.append(VelocityLayer(x))
+
+            result.append(
+                KeyMapUnit(
+                    key_root=key_root, key_low=key_low, key_high=key_high,
+                    velocity_layers=velocity_layers
+                )
+            )
+
+        return result
 
     @classmethod
     def __from_keymap_simple(cls, keymap_simple: dict) -> List['KeyMapUnit']:
@@ -161,21 +180,23 @@ class KeyMapUnit:
         Create KeyMapUnit list from json data
         """
         result: List['KeyMapUnit'] = []
-        if "midi_keymap_complex" in config_json:
-            result.extend(KeyMapUnit.__from_keymap_complex(config_json["midi_keymap_complex"]))
-        if "midi_keymap_simple" in config_json:
-            result.extend(KeyMapUnit.__from_keymap_simple(config_json["midi_keymap_simple"]))
+        if "midi_keymaps_complex" in config_json:
+            result.extend(KeyMapUnit.__from_keymap_complex(config_json["midi_keymaps_complex"]))
+        if "midi_keymaps" in config_json:
+            result.extend(KeyMapUnit.__from_keymap_simple(config_json["midi_keymaps"]))
 
         return result
 
 class MidiConfig:
 
+    # deprecated
     class ProgramChange:
         def __init__(self, progarm_change: dict) -> None:
             self.msb: int     = progarm_change["msb"]
             self.lsb: int     = progarm_change["lsb"]
             self.program: int = progarm_change["program"]
 
+    # deprecated
     class VelocityLayer:
         def __init__(self, velocity_layer: dict) -> None:
             self.min_velocity: int  = velocity_layer["min"]

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -1,5 +1,6 @@
 from typing import List
 import os
+import sys
 import json
 import jsonschema
 
@@ -135,3 +136,20 @@ class MidiConfig:
 
 def load(config_path: str) -> MidiConfig:
     return MidiConfig(config_path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Validation tool for MIDI config file")
+        print(f"Usage: python -m {__spec__.name} <config_file>")
+        sys.exit(1)
+
+    config_path = sys.argv[1]
+
+    try:
+        with open(config_path, "r") as f:
+            config_json = json.load(f)
+            jsonschema.validate(config_json, config_json_schema)
+        print("Validation OK")
+    except Exception as e:
+        print(f"Validation failed: {e}")

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -1,4 +1,5 @@
 from typing import List
+import abc
 import os
 import sys
 import json
@@ -83,6 +84,39 @@ def _parse_midi_byte_range(json_body: dict) -> List[int]:
             raise ValueError(f"Invalid data format (={json_body})")
 
     return result
+
+class KeyMapUnit:
+    """
+    Represents the smallest unit of keymap data
+    """
+    def __init__(self, key_root: int, key_low: int, key_high: int, velocity: int, low_velocity: int, high_velocity: int) -> None:
+        self.key_root: int      = key_root
+        self.key_low: int       = key_low
+        self.key_high: int      = key_high
+        self.velocity: int      = velocity
+        self.low_velocity: int  = low_velocity
+        self.high_velocity: int = high_velocity
+
+    @classmethod
+    def __from_keymap_complex(keymap_complex: dict) -> List['KeyMapUnit']:
+        """
+        Create KeyMapUnit list from json data (keymap_complex)
+        """
+        pass
+
+    @classmethod
+    def __from_keymap_simple(keymap_simple: dict) -> List['KeyMapUnit']:
+        """
+        Create KeyMapUnit list from json data (keymap_simple)
+        """
+        pass
+
+    @classmethod
+    def from_keymap(keymap_json: dict) -> List['KeyMapUnit']:
+        """
+        Create KeyMapUnit list from json data
+        """
+        pass
 
 class MidiConfig:
 

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -144,7 +144,7 @@ class KeyMapUnit:
         result: List['KeyMapUnit'] = []
 
         for key in keymap_simple:
-            notes = _parse_midi_byte_range(key["key_root"])
+            notes = _parse_midi_byte_range(key["keys"])
             velocity_layers: List[VelocityLayer] = []
 
             for x in key["velocity_layers"]:

--- a/midisampling/sampling.py
+++ b/midisampling/sampling.py
@@ -39,9 +39,9 @@ def get_output_file_prefix(format_string:str, pc_msb:int, pc_lsb:int, pc_value, 
         pc_msb (int): Program Change MSB
         pc_lsb (int): Program Change LSB
         pc_value: Program Change Value
-        key_root (int): Keymap: Root key (Send as MIDI note number to device)
-        key_low (int): Keymap: Low key
-        key_high (int): Keymap: High key
+        key_root (int): Zone: Root key (Send as MIDI note number to device)
+        key_low (int): Zone: Low key
+        key_high (int): Zone: High key
         min_velocity (int): Velocity Layer: Minimum definition
         max_velocity (int): Velocity Layer: Maximum definition
         velocity (int): Send as MIDI velocity to device
@@ -94,7 +94,7 @@ def main(args):
 
     program_change_list         = midi_config.program_change_list
     midi_channel                = midi_config.midi_channel
-    midi_keymaps                = midi_config.keymaps
+    sample_zone                 = midi_config.sample_zone
     midi_note_duration          = midi_config.midi_note_duration
     midi_pre_duration           = midi_config.midi_pre_wait_duration
     midi_release_duration       = midi_config.midi_release_duration
@@ -143,12 +143,12 @@ def main(args):
         #---------------------------------------------------------------------------
 
         # Calculate total sampling count
-        total_sampling_count = len(program_change_list) * len(midi_keymaps)
-        for k in midi_keymaps:
+        total_sampling_count = len(program_change_list) * len(sample_zone)
+        for k in sample_zone:
             total_sampling_count *= len(k.velocity_layers)
 
         if total_sampling_count == 0:
-            logger.warning("No sampling target (Notes or Velocity Layer in Keymap is empty)")
+            logger.warning("No sampling target (Sample zone is empty)")
             return
 
         # Send MIDI from file to device before sampling
@@ -170,8 +170,8 @@ def main(args):
             midi_device.send_progam_change(midi_channel, program.msb, program.lsb, program.program)
             time.sleep(0.5)
 
-            for keymap in midi_keymaps:
-                for velocity in keymap.velocity_layers:
+            for zone in sample_zone:
+                for velocity in zone.velocity_layers:
                     # Record Audio
                     record_duration = math.floor(midi_pre_duration + midi_note_duration + midi_release_duration)
 
@@ -179,8 +179,8 @@ def main(args):
                     time.sleep(midi_pre_duration)
 
                     # Play MIDI
-                    logger.info(f"[{process_count: 4d} / {total_sampling_count:4d}] Note on - Channel: {midi_channel:2d}, Note: {keymap.key_root:3d}, Velocity: {velocity.send_velocity:3d} (Key Low:{keymap.key_low:3d}, Key High:{keymap.key_high:3d}, Min Velocity:{velocity.min_velocity:3d}, Max Velocity:{velocity.max_velocity:3d})")
-                    midi_device.play_note(midi_channel, keymap.key_root, velocity.send_velocity, midi_note_duration)
+                    logger.info(f"[{process_count: 4d} / {total_sampling_count:4d}] Note on - Channel: {midi_channel:2d}, Note: {zone.key_root:3d}, Velocity: {velocity.send_velocity:3d} (Key Low:{zone.key_low:3d}, Key High:{zone.key_high:3d}, Min Velocity:{velocity.min_velocity:3d}, Max Velocity:{velocity.max_velocity:3d})")
+                    midi_device.play_note(midi_channel, zone.key_root, velocity.send_velocity, midi_note_duration)
 
                     time.sleep(midi_release_duration)
 
@@ -192,9 +192,9 @@ def main(args):
                         pc_msb=program.msb,
                         pc_lsb=program.lsb,
                         pc_value=program.program,
-                        key_root=keymap.key_root,
-                        key_low=keymap.key_low,
-                        key_high=keymap.key_high,
+                        key_root=zone.key_root,
+                        key_low=zone.key_low,
+                        key_high=zone.key_high,
                         min_velocity=velocity.min_velocity,
                         max_velocity=velocity.max_velocity,
                         velocity=velocity.send_velocity

--- a/midisampling/sampling.py
+++ b/midisampling/sampling.py
@@ -136,14 +136,21 @@ def main(args):
         # Sampling
         #---------------------------------------------------------------------------
 
+        # Calculate total sampling count
+        total_sampling_count = len(program_change_list) * len(midi_keymaps)
+        for k in midi_keymaps:
+            total_sampling_count *= len(k.velocity_layers)
+
+        if total_sampling_count == 0:
+            logger.warning("No sampling target (Notes or Velocity Layer in Keymap is empty)")
+            return
+
         # Send MIDI from file to device before sampling
         if len(pre_send_smf_path_list) > 0:
             for file in pre_send_smf_path_list:
                 logger.info(f"Send MIDI from file: {file}")
                 midi_device.send_message_from_file(file)
 
-        # Calculate total sampling count
-        total_sampling_count = len(program_change_list) * len(midi_notes) * len(midi_velocities)
 
         os.makedirs(output_dir, exist_ok=True)
 
@@ -166,7 +173,7 @@ def main(args):
                     time.sleep(midi_pre_duration)
 
                     # Play MIDI
-                    logger.info(f"[{process_count: 4d} / {total_sampling_count:4d}] Note on - Channel: {midi_channel:2d}, Note: {keymap.key_root:3d}, Velocity: {velocity.send_velocity:3d}")
+                    logger.info(f"[{process_count: 4d} / {total_sampling_count:4d}] Note on - Channel: {midi_channel:2d}, Note: {keymap.key_root:3d}, Velocity: {velocity.send_velocity:3d} (Key Low:{keymap.key_low:3d}, Key High:{keymap.key_high:3d}, Min Velocity:{velocity.min_velocity:3d}, Max Velocity:{velocity.max_velocity:3d})")
                     midi_device.play_note(midi_channel, keymap.key_root, velocity.send_velocity, midi_note_duration)
 
                     time.sleep(midi_release_duration)

--- a/midisampling/sampling.py
+++ b/midisampling/sampling.py
@@ -18,7 +18,7 @@ from midisampling.device.SdAudioDevice import SdAudioDevice
 from midisampling.appconfig.sampling import SamplingConfig
 from midisampling.appconfig.sampling import load as load_samplingconfig
 
-from midisampling.appconfig.midi import MidiConfig, VelocityLayer, KeyMapUnit
+from midisampling.appconfig.midi import MidiConfig
 from midisampling.appconfig.midi import load as load_midi_config
 
 import midisampling.dynamic_format as dynamic_format
@@ -31,29 +31,37 @@ def get_output_file_prefix(format_string:str, pc_msb:int, pc_lsb:int, pc_value, 
     Get output file prefix from dynamic format string
 
     Args:
-        format_string (str): string.format compatible format string. available placeholders are {pc_msb}, {pc_lsb}, {pc}, {note}, {velocity} and Python format specifiers are also available.
+        format_string (str): string.format compatible format string. available placeholders are
+            {pc_msb}, {pc_lsb}, {pc},
+            {key_root}, {key_low}, {key_high},
+            {velocity}, {min_velocity}, {max_velocity}
+            and Python format specifiers are also available.
         pc_msb (int): Program Change MSB
         pc_lsb (int): Program Change LSB
         pc_value: Program Change Value
-        note (int): MIDI Note
+        key_root (int): Keymap: Root key (Send as MIDI note number to device)
+        key_low (int): Keymap: Low key
+        key_high (int): Keymap: High key
         min_velocity (int): Velocity Layer: Minimum definition
         max_velocity (int): Velocity Layer: Maximum definition
-        velocity (int): MIDI Velocity
+        velocity (int): Send as MIDI velocity to device
 
     Returns:
         str: formatted string
     """
+
+    logger.debug(f"{get_output_file_prefix.__name__}: {locals()}")
+
     format_value = {
         "pc_msb": pc_msb,
         "pc_lsb": pc_lsb,
         "pc": pc_value,
-        "note": key_root, # deprecated
         "key_root": key_root,
         "key_low": key_low,
         "key_high": key_high,
+        "velocity": velocity,
         "min_velocity": min_velocity,
         "max_velocity": max_velocity,
-        "velocity": velocity # deprecated
     }
 
     return dynamic_format.format(format_string=format_string, data=format_value)
@@ -87,8 +95,6 @@ def main(args):
     program_change_list         = midi_config.program_change_list
     midi_channel                = midi_config.midi_channel
     midi_keymaps                = midi_config.keymaps
-    midi_notes                  = midi_config.midi_notes
-    midi_velocities             = midi_config.midi_velocity_layers
     midi_note_duration          = midi_config.midi_note_duration
     midi_pre_duration           = midi_config.midi_pre_wait_duration
     midi_release_duration       = midi_config.midi_release_duration


### PR DESCRIPTION
## Sample Zone difinition support in MIDI sampling setting (destructive change)

2 type of zone difinition will be supported.

### sample_zone_complex

Sample zone complex configuration. The key range, root key, must be specified explicitly.

```json
"sample_zone_complex": [
    {
        "key_low": 0,
        "key_high": 32,
        "key_root": 16,
        "velocity_layers": [
            { "min": 0,  "max": 31,  "send": 31 },
            { "min": 32, "max": 63,  "send": 63 },
            { "min": 64, "max": 95,  "send": 95 },
            { "min": 96, "max": 127, "send": 127 }
        ]
    }
]
```

### sample_zone

A simple configuration of sample zone. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`.

```json
"sample_zone": [
    {
        "keys": {"from": 40, "to": 40},
        "velocity_layers": [
            {"min": 0,  "max": 31,  "send": 31},
            {"min": 32, "max": 63,  "send": 63},
            {"min": 64, "max": 95,  "send": 95},
            {"min": 96, "max": 127, "send": 127}
        ]
    }
]
```

## Updated `output_prefix_format` placeholder

### Obsoleted

- `{note}`

### Added

- `{key_root}`
- `{key_low}`
- `{key_high}`


## Obsolete MIDI sampling setting items

- `{midi_notes}`
- `{midi_velocity_layers}`