### PR TITLE
Refactor/output directory

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,1 +1,2 @@
 _[Rr]ecorded/
+_[Pp]rocessed/

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -1,6 +1,6 @@
 {
     "output_dir": "_recorded",
-    "processed_output_dir": "_recorded/_processed",
+    "processed_output_dir": "_processed",
     "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{key_low}_{key_high}_{velocity}_{min_velocity}_{max_velocity}",
     "pre_send_smf_path_list": [
         "GS_Reset.mid",

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -251,6 +251,9 @@ class MidiConfig:
         self.processed_output_dir = _to_abs_filepath(self.config_dir, self.processed_output_dir)
         self.pre_send_smf_path_list = _to_abs_filepath_list(self.config_dir, self.pre_send_smf_path_list)
 
+        if self.output_dir == self.processed_output_dir or self.processed_output_dir.startswith(self.output_dir):
+            raise ValueError(f"processed_output_dir must be outside of output_dir.\n\toutput_dir={self.output_dir}\n\tprocessed_output_dir={self.processed_output_dir})")
+
         # Zone
         self.sample_zone = SampleZone.from_json(config_json)
 

--- a/midisampling/exportpath.py
+++ b/midisampling/exportpath.py
@@ -1,0 +1,126 @@
+import abc
+from typing import List, override
+
+import os
+import pathlib
+
+class IExportingAudioPath(metaclass=abc.ABCMeta):
+    """
+    Exporting audio path information.
+    Implementations should implement __eq__ and __hash__ methods for comparison.
+    """
+
+    @abc.abstractmethod
+    def path(self) -> str:
+        """
+        Get joined path of base_dir and file_path
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def makedirs(self):
+        """
+        Create directory by using `base_dir + file_path`
+        """
+        raise NotImplementedError
+
+class RecordedAudioPath(IExportingAudioPath):
+    """
+    Exporting audio path information
+    """
+
+    def __init__(self, base_dir:str, file_path:str):
+        self.base_dir: str  = base_dir
+        self.file_path: str = os.path.normpath(file_path)
+
+    @override
+    def path(self) -> str:
+        """
+        Get joined path of base_dir and file_path
+        """
+        return os.path.join(self.base_dir, self.file_path)
+
+    @override
+    def makedirs(self):
+        """
+        Create directory by using `base_dir + file_path`
+        """
+
+        target = os.path.dirname(self.path())
+        if len(target) > 0:
+            os.makedirs(target, exist_ok=True)
+
+    def __str__(self):
+        return f"base_dir={self.base_dir}, file_path={self.file_path}"
+
+    def __eq__(self, other):
+        if not isinstance(other, RecordedAudioPath):
+            return False
+
+        return (
+            self.base_dir == other.base_dir
+            and self.file_path == other.file_path
+        )
+
+    def __hash__(self):
+        return hash((self.base_dir, self.file_path))
+
+class PostProcessedAudioPath(IExportingAudioPath):
+    """
+    Exporting audio path information for post process
+    """
+    def __init__(self, recorded_audio_path: RecordedAudioPath, base_dir: str, overwrite: bool = False):
+
+        if base_dir == recorded_audio_path.base_dir and not overwrite:
+            raise ValueError("base_dir and recorded_audio_path.base_dir must be different. If you want to force overwrite, set overwrite to enable.")
+
+        self.recorded_audio_path: RecordedAudioPath = recorded_audio_path
+        self.base_dir: str  = base_dir
+        self.file_path: str = os.path.normpath(recorded_audio_path.file_path)
+
+    @classmethod
+    def from_directory(cls, input_directory: str, output_directory: str, search_extension: str = ".wav", overwrite: bool = False) -> List['PostProcessedAudioPath']:
+
+        input_directory = os.path.normpath(os.path.abspath(input_directory))
+        output_directory = os.path.normpath(os.path.abspath(output_directory))
+
+        if not os.path.exists(input_directory):
+            raise FileNotFoundError(f"input_directory not found: {input_directory}")
+
+        directory = pathlib.Path(input_directory)
+        files = list(directory.glob(f"**/*{search_extension}"))
+
+        result: List[PostProcessedAudioPath] = []
+
+        for f in files:
+            file_path = os.path.normpath(str(f.relative_to(directory)))
+            source    = RecordedAudioPath(base_dir=input_directory, file_path=file_path)
+            result.append(PostProcessedAudioPath(recorded_audio_path=source, base_dir=output_directory, overwrite=overwrite))
+
+        return result
+
+    @override
+    def path(self) -> str:
+        return os.path.join(self.base_dir, self.file_path)
+
+    @override
+    def makedirs(self):
+        target = os.path.dirname(self.path())
+        if len(target) > 0:
+            os.makedirs(target, exist_ok=True)
+
+    def __str__(self):
+        return f"base_dir={self.base_dir}, file_path={self.file_path}, recorded_audio_path={self.recorded_audio_path}"
+
+
+    def __eq__(self, other):
+        if not isinstance(other, RecordedAudioPath):
+            return False
+
+        return (
+            self.base_dir == other.base_dir
+            and self.file_path == other.file_path
+        )
+
+    def __hash__(self):
+        return hash((self.base_dir, self.file_path))

--- a/midisampling/waveprocess/__main__.py
+++ b/midisampling/waveprocess/__main__.py
@@ -19,6 +19,7 @@ def main() -> None:
     normalize_parser.add_argument("input_directory", help="Path to the input directory with audio files (*.wav).")
     normalize_parser.add_argument("output_directory", help="Path to the output directory to save the normalized audio files.")
     normalize_parser.add_argument("target_db", type=float, help="Target decibel level for normalization.")
+    normalize_parser.add_argument("-o", "--overwrite", help="Overwrite the original audio files.", action="store_true")
 
     # Trim
     trim_parser = subparsers.add_parser("trim")
@@ -26,6 +27,7 @@ def main() -> None:
     trim_parser.add_argument("output_directory", help="Path to the output directory to save the trimmed audio files.")
     trim_parser.add_argument("threshold", type=float, help="Threshold for trimming silence. (db)")
     trim_parser.add_argument("min_silence", type=int, help="Minimum silence duration to be trimmed. (msec)")
+    trim_parser.add_argument("-o", "--overwrite", help="Overwrite the original audio files.", action="store_true")
 
 
     args = parser.parse_args()
@@ -36,17 +38,19 @@ def main() -> None:
         # Process
 
         if args.command == "normalize":
-            normalize.normalize_across_mitiple(
+            normalize.normalize_from_directory(
                 input_directory=args.input_directory,
                 output_directory=args.output_directory,
-                target_peak_dBFS=args.target_db
+                target_peak_dBFS=args.target_db,
+                overwrite=args.overwrite
             )
         elif args.command == "trim":
-            trim.batch_trim(
+            trim.trim_from_directory(
                 input_directory=args.input_directory,
                 output_directory=args.output_directory,
                 threshold_dBFS=args.threshold,
-                min_silence_ms=args.min_silence
+                min_silence_ms=args.min_silence,
+                overwrite=args.overwrite
             )
     except Exception as e:
         print(e)

--- a/midisampling/waveprocess/normalize.py
+++ b/midisampling/waveprocess/normalize.py
@@ -1,11 +1,69 @@
+from typing import List
+
 import os
-import sys
+import pathlib
 from logging import getLogger
 from pydub import AudioSegment
 
+from midisampling.exportpath import RecordedAudioPath, PostProcessedAudioPath
+
 logger = getLogger(__name__)
 
-def normalize_across_mitiple(input_directory: str, output_directory: str, target_peak_dBFS:float =-1.0):
+def normalize_from_list(file_list: List[PostProcessedAudioPath], target_peak_dBFS:float =-1.0):
+    """
+    Normalize with respect to the highest peak of the audio file(s) in the input directory.
+
+    Parameters
+    ----------
+    file_list : List[PostProcessedAudioPath]
+        List of PostProcessedAudioPath instances.
+
+    target_peak_dBFS : float (default=-1.0)
+    """
+
+    if file_list is None:
+        raise ValueError("file_list is None")
+    if len(file_list) == 0:
+        raise ValueError("file_list is empty")
+
+    max_peak_dBFS = None
+    audio_segments = []
+
+    logger.info("Normalize Begin")
+
+    # 全てのファイルの最大ピークレベルを探す
+    for file in file_list:
+        input_filepath  = file.recorded_audio_path.path()
+        output_filepath = file.path()
+        audio           = AudioSegment.from_wav(input_filepath)
+        peak_dBFS = audio.max_dBFS
+        audio = None
+
+        if max_peak_dBFS is None or peak_dBFS > max_peak_dBFS:
+            max_peak_dBFS = peak_dBFS
+
+        audio_segments.append((audio, output_filepath))
+
+    change_in_dBFS = target_peak_dBFS - max_peak_dBFS
+
+    # 各ファイルに対して同じゲインを適用
+    for file in file_list:
+        input_filepath  = file.recorded_audio_path.path()
+        output_filepath = file.path()
+        audio           = AudioSegment.from_wav(input_filepath)
+
+        file.makedirs()
+        normalized_audio = audio.apply_gain(change_in_dBFS)
+        normalized_audio.export(output_filepath, format="wav")
+
+        audio = None
+        normalized_audio = None
+
+        logger.info(f"Normalized: file={file.path()}")
+
+    logger.info(f"Normalize End (gain={change_in_dBFS:.3f} dBFS)")
+
+def normalize_from_directory(input_directory: str, output_directory: str, target_peak_dBFS:float =-1.0, overwrite: bool = False):
     """
     Normalize with respect to the highest peak of the audio file(s) in the input directory.
 
@@ -19,33 +77,11 @@ def normalize_across_mitiple(input_directory: str, output_directory: str, target
 
     target_peak_dBFS : float (default=-1.0)
     """
-    max_peak_dBFS = None
-    audio_segments = []
 
-    os.makedirs(output_directory, exist_ok=True)
+    process_files: List[PostProcessedAudioPath] = PostProcessedAudioPath.from_directory(
+        input_directory=input_directory,
+        output_directory=output_directory,
+        overwrite=overwrite
+    )
 
-    logger.info("Normalize Begin")
-    logger.debug(f"Normalize Begin: {locals()}")
-
-    # 全てのファイルの最大ピークレベルを探す
-    for filename in os.listdir(input_directory):
-        if filename.endswith('.wav'):
-            input_filepath  = os.path.join(input_directory, filename)
-            output_filepath = os.path.join(output_directory, filename)
-            audio = AudioSegment.from_wav(input_filepath)
-            peak_dBFS = audio.max_dBFS
-
-            if max_peak_dBFS is None or peak_dBFS > max_peak_dBFS:
-                max_peak_dBFS = peak_dBFS
-
-            audio_segments.append((audio, output_filepath))
-
-    change_in_dBFS = target_peak_dBFS - max_peak_dBFS
-
-    # 各ファイルに対して同じゲインを適用
-    for audio, output_filepath in audio_segments:
-        normalized_audio = audio.apply_gain(change_in_dBFS)
-        normalized_audio.export(output_filepath, format="wav")
-        logger.info(f"Normalized: file={os.path.basename(output_filepath)}")
-
-    logger.info(f"Normalize End (gain={change_in_dBFS:.3f} dBFS)")
+    normalize_from_list(process_files, target_peak_dBFS)

--- a/midisampling/waveprocess/trim.py
+++ b/midisampling/waveprocess/trim.py
@@ -1,10 +1,14 @@
+from typing import List
+
 import os
-import sys
+import pathlib
 import shutil
 from logging import getLogger
 
 from pydub import AudioSegment
 from pydub.silence import detect_nonsilent
+
+from midisampling.exportpath import RecordedAudioPath, PostProcessedAudioPath
 
 logger = getLogger(__name__)
 
@@ -30,8 +34,6 @@ def trim(input_path:str, output_path: str, threshold_dBFS:float=-50, min_silence
     audio = AudioSegment.from_wav(input_path)
     nonsilent_ranges = detect_nonsilent(audio, min_silence_len=min_silence_ms, silence_thresh=threshold_dBFS)
 
-    result_message = f"input={input_path}, output={output_path}, threshold_dBFS={threshold_dBFS}, min_silence_ms={min_silence_ms}"
-
     if nonsilent_ranges:
         start, end = nonsilent_ranges[0][0], nonsilent_ranges[-1][1]
         trimmed_audio = audio[start:end]
@@ -41,7 +43,37 @@ def trim(input_path:str, output_path: str, threshold_dBFS:float=-50, min_silence
             shutil.copy(input_path, output_path)
 
 
-def batch_trim(input_directory: str, output_directory: str, threshold_dBFS:float=-50, min_silence_ms:int=250):
+def trim_from_list(file_list: List[PostProcessedAudioPath], threshold_dBFS:float=-50, min_silence_ms:int=250):
+    """
+    Trim silent segments from all audio files in the input directory.
+
+    Parameters
+    ----------
+    file_list : List[PostProcessedAudioPath]
+        List of PostProcessedAudioPath instances.
+
+    threshold_dBFS : float (default=-50)
+        Silence threshold in dBFS.
+
+    min_silence_ms : int (default=250)
+        Minimum silence duration in milliseconds.
+    """
+
+    if file_list is None:
+        raise ValueError("file_list is None")
+    if len(file_list) == 0:
+        raise ValueError("file_list is empty")
+
+    for file in file_list:
+        input_path  = file.recorded_audio_path.path()
+        output_path = file.path()
+        file.makedirs()
+        trim(input_path, output_path, threshold_dBFS, min_silence_ms)
+        logger.info(f"Trimmed: {file.path()}")
+
+    logger.info(f"Trim End")
+
+def trim_from_directory(input_directory: str, output_directory: str, threshold_dBFS:float=-50, min_silence_ms:int=250, overwrite: bool = False):
     """
     Trim silent segments from all audio files in the input directory.
 
@@ -60,16 +92,9 @@ def batch_trim(input_directory: str, output_directory: str, threshold_dBFS:float
         Minimum silence duration in milliseconds.
     """
 
-    os.makedirs(output_directory, exist_ok=True)
-
-    logger.info("Trim Begin")
-    logger.debug(f"Trim Begin: {locals()}")
-
-    for filename in os.listdir(input_directory):
-        if filename.endswith('.wav'):
-            input_path = os.path.join(input_directory, filename)
-            output_path = os.path.join(output_directory, filename)
-            trim(input_path, output_path, threshold_dBFS, min_silence_ms)
-            logger.info(f"Trimmed: {filename}")
-
-    logger.info(f"Trim End")
+    process_files: List[PostProcessedAudioPath] = PostProcessedAudioPath.from_directory(
+        input_directory=input_directory,
+        output_directory=output_directory,
+        overwrite=overwrite
+    )
+    trim_from_list(process_files, threshold_dBFS, min_silence_ms)


### PR DESCRIPTION
## Improved output directory operations

- During post-processing, built with the same structure as the output directory structure of sampling
- Support for including directories in `output_prefix_format` to be reflected.
- More rigorous checking of sampling output directory and post-process output directory
  - Post-process output directory cannot be set below sampling output directory (to preserve original data)