### PR TITLE
Feature/notenumber to scalename placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
 - <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(object)*: The main configuration body. Cannot contain additional properties.
   - **`output_dir`** *(string, required)*: Directory for the output of the sampled audio files.
   - **`processed_output_dir`** *(string, required)*: Directory for the output of processed sampled audio files.
-  - **`output_prefix_format`** *(string)*: Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {min_velocity} {max_velocity} {velocity}. Default: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`.
+  - **`output_prefix_format`** *(string)*: Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity} {max_velocity} {velocity}. Default: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`.
+  - **`scale_name_format`** *(string)*: Format for representation by keyscale name, e.g. Scientific pitch notation with C3 = 60 or Yamaha method with C4 = 60. Works as a placeholder replacement. Must be one of: `["SPN", "Yamaha"]`. Default: `"Yamaha"`.
   - **`pre_send_smf_path_list`** *(array)*: These file(s) will be sent to the MIDI device before sampling once e.g. GM Reset, CC Reset, etc. Default: `[]`.
     - **Items** *(string)*: Path to the SMF(*.mid/*.midi) file(s).
   - **`midi_channel`** *(integer, required)*: MIDI channel number for sampling. Minimum: `0`. Maximum: `15`.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   - **`output_dir`** *(string, required)*: Directory for the output of the sampled audio files.
   - **`processed_output_dir`** *(string, required)*: Directory for the output of processed sampled audio files.
   - **`output_prefix_format`** *(string)*: Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity} {max_velocity} {velocity}. Default: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`.
-  - **`scale_name_format`** *(string)*: Format for representation by keyscale name, e.g. Scientific pitch notation with C3 = 60 or Yamaha method with C4 = 60. Works as a placeholder replacement. Must be one of: `["SPN", "Yamaha"]`. Default: `"Yamaha"`.
+  - **`scale_name_format`** *(string)*: Format for representation by keyscale name, e.g. Scientific pitch notation with C4 = 60 or Yamaha method with C3 = 60. Works as a placeholder replacement. Must be one of: `["SPN", "Yamaha"]`. Default: `"Yamaha"`.
   - **`pre_send_smf_path_list`** *(array)*: These file(s) will be sent to the MIDI device before sampling once e.g. GM Reset, CC Reset, etc. Default: `[]`.
     - **Items** *(string)*: Path to the SMF(*.mid/*.midi) file(s).
   - **`midi_channel`** *(integer, required)*: MIDI channel number for sampling. Minimum: `0`. Maximum: `15`.

--- a/README_ja.md
+++ b/README_ja.md
@@ -157,7 +157,8 @@ python -m midisampling.device
 - <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(オブジェクト)*: メイン構成本体。追加のプロパティは含めることができません。
   - **`output_dir`** *(文字列, 必須)*: サンプリングされたオーディオファイルの出力先ディレクトリ。
   - **`processed_output_dir`** *(文字列, 必須)*: 処理されたサンプリングオーディオファイルの出力先ディレクトリ。
-  - **`output_prefix_format`** *(文字列)*: サンプリングされたオーディオファイルのファイル名の接頭辞。このプレースホルダーが使用できます: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {min_velocity} {max_velocity} {velocity}。デフォルト: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`。
+  - **`output_prefix_format`** *(文字列)*: サンプルされたオーディオファイルのファイル名のプレフィックス。以下のプレースホルダーを使用できます: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity}, {max_velocity}, {velocity}。デフォルト: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`。
+  - **`scale_name_format`** *(文字列)*: キースケール名の表現フォーマット。例: C3 = 60を示す科学的ピッチ表記法（SPN）や、C4 = 60を示すヤマハ方式。プレースホルダーの置き換えとして機能します。次のいずれかである必要があります: `["SPN", "Yamaha"]`。デフォルト: `"Yamaha"`。
   - **`pre_send_smf_path_list`** *(配列)*: サンプリングの前にMIDIデバイスに送信されるファイル（例：GMリセット、CCリセットなど）。デフォルト: `[]`。
     - **アイテム** *(文字列)*: SMF(*.mid/*.midi)ファイルへのパス。
   - **`midi_channel`** *(整数, 必須)*: サンプリング用のMIDIチャンネル番号。最小: `0`。最大: `15`。

--- a/README_ja.md
+++ b/README_ja.md
@@ -158,7 +158,7 @@ python -m midisampling.device
   - **`output_dir`** *(文字列, 必須)*: サンプリングされたオーディオファイルの出力先ディレクトリ。
   - **`processed_output_dir`** *(文字列, 必須)*: 処理されたサンプリングオーディオファイルの出力先ディレクトリ。
   - **`output_prefix_format`** *(文字列)*: サンプルされたオーディオファイルのファイル名のプレフィックス。以下のプレースホルダーを使用できます: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity}, {max_velocity}, {velocity}。デフォルト: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`。
-  - **`scale_name_format`** *(文字列)*: キースケール名の表現フォーマット。例: C3 = 60を示す科学的ピッチ表記法（SPN）や、C4 = 60を示すヤマハ方式。プレースホルダーの置き換えとして機能します。次のいずれかである必要があります: `["SPN", "Yamaha"]`。デフォルト: `"Yamaha"`。
+  - **`scale_name_format`** *(文字列)*: キースケール名の表現フォーマット。例: C4 = 60を示す科学的ピッチ表記法（SPN）や、C3 = 60を示すヤマハ方式。プレースホルダーの置き換えとして機能します。次のいずれかである必要があります: `["SPN", "Yamaha"]`。デフォルト: `"Yamaha"`。
   - **`pre_send_smf_path_list`** *(配列)*: サンプリングの前にMIDIデバイスに送信されるファイル（例：GMリセット、CCリセットなど）。デフォルト: `[]`。
     - **アイテム** *(文字列)*: SMF(*.mid/*.midi)ファイルへのパス。
   - **`midi_channel`** *(整数, 必須)*: サンプリング用のMIDIチャンネル番号。最小: `0`。最大: `15`。

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -18,8 +18,14 @@
                 },
                 "output_prefix_format": {
                     "type": "string",
-                    "description": "Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {min_velocity} {max_velocity} {velocity}.",
+                    "description": "Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity} {max_velocity} {velocity}.",
                     "default": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"
+                },
+                "scale_name_format": {
+                    "type": "string",
+                    "description": "Format for representation by keyscale name, e.g. Scientific pitch notation with C3 = 60 or Yamaha method with C4 = 60. Works as a placeholder replacement.",
+                    "enum": ["SPN", "Yamaha"],
+                    "default": "Yamaha"
                 },
                 "pre_send_smf_path_list" : {
                     "type":"array",

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -111,6 +111,7 @@
                     "output_dir": "_recorded",
                     "processed_output_dir": "_recorded/_processed",
                     "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
+                    "scale_name_format": "Yamaha",
                     "pre_send_smf_path_list": [
                         "path/to/GM_Reset.mid",
                         "path/to/CC_Init.mid"

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -238,6 +238,7 @@ class MidiConfig:
         self.output_dir: str                            = config_json["output_dir"]
         self.processed_output_dir: str                  = config_json["processed_output_dir"]
         self.output_prefix_format: str                  = config_json["output_prefix_format"]
+        self.scale_name_format: str                     = config_json.get("scale_name_format", "Yamaha")
         self.pre_send_smf_path_list: List[str]          = config_json["pre_send_smf_path_list"]
         self.midi_channel: int                          = config_json["midi_channel"]
         self.program_change_list: List[ProgramChange]   = []

--- a/midisampling/notenumber.py
+++ b/midisampling/notenumber.py
@@ -1,0 +1,75 @@
+from typing import Dict
+
+# middle C
+#
+# [e.g.]
+#
+# SPN (Scientific pitch notation)
+#   Note No 60 = C4
+#
+# Yamaha
+#   Note No 60 = C3
+
+_notenumber_scale_table: Dict[int, str] = {}
+_scale_notenumber_table: Dict[str, int] = {}
+_notenumber_scale_yamaha_table: Dict[int, str] = {}
+_scale_notenumber_yamaha_table: Dict[str, int] = {}
+
+_scales = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+# Create tables
+for x in range(128):
+    def create_table_impl(n: int, octave_begin: int, dest_nn_sc: dict, dest_sc_nn: dict) -> None:
+        note      = n % 12
+        octave    = n // 12 + octave_begin
+        note_name = f"{_scales[note]}{octave}"
+        dest_nn_sc[n] = note_name
+        dest_sc_nn[note_name] = n
+
+    def create_table(n: int) -> None:
+        create_table_impl(n, -1, _notenumber_scale_table, _scale_notenumber_table)
+
+    def create_table_yamaha(n: int) -> None:
+        create_table_impl(n, -2, _notenumber_scale_yamaha_table, _scale_notenumber_yamaha_table)
+
+    create_table(x)
+    create_table_yamaha(x)
+
+
+def as_scalename(note_number: int, spn_format: bool = False) -> str:
+    """
+    Convert note number to scale name ('C-1', 'C#-1' etc.).
+
+    Parameters
+    ----------
+    note_number : int
+        Note number (0-127).
+
+    spn_format : bool, optional
+        default: False
+        If True, return in Scientific pitch notation format (note number 60 = 'C4').
+        If False, return in aka Yamaha format (note number 60 = 'C3').
+    """
+    if spn_format:
+        return _notenumber_scale_table[note_number]
+    else:
+        return _notenumber_scale_yamaha_table[note_number]
+
+def as_notenumber(scalename: str, spn_format: bool = False) -> int:
+    """
+    Convert scale name ('C-1', 'C#-1' etc.) to note number.
+
+    Parameters
+    ----------
+    scalename : str
+        Scale name ('C-1', 'C#-1' etc.).
+
+    spn_format : bool, optional
+        default: False
+        If True, return in Scientific pitch notation format ('C4' = note number 60).
+        If False, return in aka Yamaha format ('C3' = note number 60).
+    """
+    if spn_format:
+        return _scale_notenumber_table[scalename]
+    else:
+        return _scale_notenumber_yamaha_table[scalename]

--- a/midisampling/sampling.py
+++ b/midisampling/sampling.py
@@ -42,7 +42,6 @@ def expand_path_placeholder(format_string:str, pc_msb:int, pc_lsb:int, pc_value,
             {pc_msb}, {pc_lsb}, {pc},
             {key_root}, {key_low}, {key_high},
             {key_root_scale}, {key_low_scale}, {key_high_scale},
-            {key_root_scale_y}, {key_low_scale_y}, {key_high_scale_y} (notice: ???_y = yamaha format),
             {velocity}, {min_velocity}, {max_velocity}
             and Python format specifiers are also available.
         pc_msb (int): Program Change MSB


### PR DESCRIPTION
## note number to scale name conveting supported

Configure in midi-sampling config.

- Scientific pitch notation (60 = C4)
- Yamaha (60 = C3)
