### PR TITLE
Supporting Preset definition for velocity layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   - **`output_dir`** *(string, required)*: Directory for the output of the sampled audio files.
   - **`processed_output_dir`** *(string, required)*: Directory for the output of processed sampled audio files.
   - **`output_prefix_format`** *(string)*: Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity} {max_velocity} {velocity}. Default: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`.
-  - **`scale_name_format`** *(string)*: Format for representation by keyscale name, e.g. Scientific pitch notation with C4 = 60 or Yamaha method with C3 = 60. Works as a placeholder replacement. Must be one of: `["SPN", "Yamaha"]`. Default: `"Yamaha"`.
+  - **`scale_name_format`** *(string)*: Format for representation by keyscale name, e.g. Scientific pitch notation with C3 = 60 or Yamaha method with C4 = 60. Works as a placeholder replacement. Must be one of: `["SPN", "Yamaha"]`. Default: `"Yamaha"`.
   - **`pre_send_smf_path_list`** *(array)*: These file(s) will be sent to the MIDI device before sampling once e.g. GM Reset, CC Reset, etc. Default: `[]`.
     - **Items** *(string)*: Path to the SMF(*.mid/*.midi) file(s).
   - **`midi_channel`** *(integer, required)*: MIDI channel number for sampling. Minimum: `0`. Maximum: `15`.
@@ -162,6 +162,8 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
       - **`msb`** *(integer)*: MSB value for the MIDI program change. Minimum: `0`. Maximum: `127`.
       - **`lsb`** *(integer)*: LSB value for the MIDI program change. Minimum: `0`. Maximum: `127`.
       - **`program`** *(integer)*: Program number for the MIDI program change. Minimum: `0`. Maximum: `127`.
+  - **`velocity_layers_presets`** *(array)*: List of velocity layers presets. In addition to defining individual layers with `sample_zone_complex` and `sample_zone`, you can also refer to this preset by ID.
+    - **Items**: Refer to *[#/definitions/def_velocity_layers_preset](#definitions/def_velocity_layers_preset)*.
   - **`sample_zone_complex`** *(array)*: List of keymaps for the sampled MIDI notes.
     - **Items**: Refer to *[#/definitions/def_sample_zone_complex](#definitions/def_sample_zone_complex)*.
   - **`sample_zone`** *(array)*: List of keymaps for the sampled MIDI notes.
@@ -176,6 +178,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
       "output_dir": "_recorded",
       "processed_output_dir": "_recorded/_processed",
       "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
+      "scale_name_format": "Yamaha",
       "pre_send_smf_path_list": [
           "path/to/GM_Reset.mid",
           "path/to/CC_Init.mid"
@@ -198,6 +201,33 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
               "program": 2
           }
       ],
+      "velocity_layers_presets": [
+          {
+              "id": 0,
+              "layers": [
+                  {
+                      "min": 0,
+                      "max": 31,
+                      "send": 31
+                  },
+                  {
+                      "min": 32,
+                      "max": 63,
+                      "send": 63
+                  },
+                  {
+                      "min": 64,
+                      "max": 95,
+                      "send": 95
+                  },
+                  {
+                      "min": 96,
+                      "max": 127,
+                      "send": 127
+                  }
+              ]
+          }
+      ],
       "sample_zone": [
           {
               "key_root": {
@@ -207,17 +237,24 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
               "velocity_layers": [
                   {
                       "min": 0,
-                      "max": 63,
-                      "send": 63
+                      "max": 127,
+                      "send": 127
                   }
               ]
+          },
+          {
+              "key_root": {
+                  "from": 62,
+                  "to": 63
+              },
+              "velocity_layers_preset_id": 0
           }
       ],
       "sample_zone_complex": [
           {
               "key_low": 0,
-              "key_high": 0,
-              "key_root": 40,
+              "key_high": 40,
+              "key_root": 20,
               "velocity_layers": [
                   {
                       "min": 0,
@@ -225,6 +262,12 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
                       "send": 63
                   }
               ]
+          },
+          {
+              "key_low": 40,
+              "key_high": 60,
+              "key_root": 50,
+              "velocity_layers_preset_id": 0
           }
       ],
       "midi_pre_wait_duration": 0.6,
@@ -272,13 +315,49 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   }
   ```
 
+- <a id="definitions/def_velocity_layers_preset"></a>**`def_velocity_layers_preset`** *(object)*: Velocity layers preset configuration. Cannot contain additional properties.
+  - **`id`** *(integer, required)*: ID of the velocity layer preset.
+  - **`layers`** *(array, required)*
+    - **Items**:
+        - : Refer to *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*.
+
+  Examples:
+  ```json
+  {
+      "id": 0,
+      "layers": [
+          {
+              "min": 0,
+              "max": 31,
+              "send": 31
+          },
+          {
+              "min": 32,
+              "max": 63,
+              "send": 63
+          },
+          {
+              "min": 64,
+              "max": 95,
+              "send": 95
+          },
+          {
+              "min": 96,
+              "max": 127,
+              "send": 127
+          }
+      ]
+  }
+  ```
+
 - <a id="definitions/def_sample_zone_complex"></a>**`def_sample_zone_complex`** *(object)*: Sample zone complex configuration. The key range, root key, must be specified explicitly. Cannot contain additional properties.
   - **`key_low`** *(integer, required)*: Lowest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software. Minimum: `0`. Maximum: `127`.
   - **`key_high`** *(integer, required)*: Highest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software. Minimum: `0`. Maximum: `127`.
   - **`key_root`** *(integer, required)*: Root key number (note number) in the keymap. This value is intended to be used as information for mapping note-on messages sent to MIDI devices and third-party sampler software when sampling. Minimum: `0`. Maximum: `127`.
-  - **`velocity_layers`** *(array, required)*
+  - **`velocity_layers`** *(array)*
     - **Items**:
         - : Refer to *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*.
+  - **`velocity_layers_preset_id`** *(integer)*: ID of the velocity layer preset.
 
   Examples:
   ```json
@@ -311,11 +390,21 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   }
   ```
 
+  ```json
+  {
+      "key_low": 0,
+      "key_high": 32,
+      "key_root": 16,
+      "velocity_layers_preset_id": 0
+  }
+  ```
+
 - <a id="definitions/def_sample_zone"></a>**`def_sample_zone`** *(object)*: A simple configuration of sample zone. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`. Cannot contain additional properties.
   - **`keys`**: Root key number (note number) in the keymap. Refer to *[#/definitions/def_midi_message_byte_range](#definitions/def_midi_message_byte_range)*.
-  - **`velocity_layers`** *(array, required)*
+  - **`velocity_layers`** *(array)*
     - **Items**:
         - : Refer to *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*.
+  - **`velocity_layers_preset_id`** *(integer)*: ID of the velocity layer preset.
 
   Examples:
   ```json
@@ -346,6 +435,16 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
               "send": 127
           }
       ]
+  }
+  ```
+
+  ```json
+  {
+      "keys": {
+          "from": 10,
+          "to": 100
+      },
+      "velocity_layers_preset_id": 0
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -176,29 +176,18 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   ```json
   {
       "output_dir": "_recorded",
-      "processed_output_dir": "_recorded/_processed",
-      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
-      "scale_name_format": "Yamaha",
+      "processed_output_dir": "_processed",
+      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{key_low}_{key_high}_{velocity}_{min_velocity}_{max_velocity}",
       "pre_send_smf_path_list": [
-          "path/to/GM_Reset.mid",
-          "path/to/CC_Init.mid"
+          "GS_Reset.mid",
+          "Reverb_Chorus_Delay_Set_0.mid"
       ],
       "midi_channel": 0,
       "midi_program_change_list": [
           {
               "msb": 0,
               "lsb": 0,
-              "program": 0
-          },
-          {
-              "msb": 0,
-              "lsb": 0,
-              "program": 1
-          },
-          {
-              "msb": 0,
-              "lsb": 0,
-              "program": 2
+              "program": 48
           }
       ],
       "velocity_layers_presets": [
@@ -228,45 +217,75 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
               ]
           }
       ],
-      "sample_zone": [
+      "sample_zone_complex": [
           {
-              "key_root": {
-                  "from": 40,
-                  "to": 41
-              },
+              "key_low": 0,
+              "key_high": 32,
+              "key_root": 16,
               "velocity_layers": [
                   {
                       "min": 0,
+                      "max": 31,
+                      "send": 31
+                  },
+                  {
+                      "min": 32,
+                      "max": 63,
+                      "send": 63
+                  },
+                  {
+                      "min": 64,
+                      "max": 95,
+                      "send": 95
+                  },
+                  {
+                      "min": 96,
                       "max": 127,
                       "send": 127
                   }
               ]
           },
           {
-              "key_root": {
-                  "from": 62,
-                  "to": 63
-              },
+              "key_low": 32,
+              "key_high": 64,
+              "key_root": 48,
               "velocity_layers_preset_id": 0
           }
       ],
-      "sample_zone_complex": [
+      "sample_zone": [
           {
-              "key_low": 0,
-              "key_high": 40,
-              "key_root": 20,
+              "keys": {
+                  "from": 40,
+                  "to": 40
+              },
               "velocity_layers": [
                   {
                       "min": 0,
+                      "max": 31,
+                      "send": 31
+                  },
+                  {
+                      "min": 32,
                       "max": 63,
                       "send": 63
+                  },
+                  {
+                      "min": 64,
+                      "max": 95,
+                      "send": 95
+                  },
+                  {
+                      "min": 96,
+                      "max": 127,
+                      "send": 127
                   }
               ]
           },
           {
-              "key_low": 40,
-              "key_high": 60,
-              "key_root": 50,
+              "keys": {
+                  "from": 41,
+                  "to": 41
+              },
               "velocity_layers_preset_id": 0
           }
       ],

--- a/README_ja.md
+++ b/README_ja.md
@@ -148,32 +148,34 @@ python -m midisampling.device
   }
   ```
 
-### MIDIサンプリング構成
+### MIDIサンプリング設定
 
-*MIDIサンプリング構成の構造。*
+*MIDIサンプリング設定の構造。*
 
 #### 定義
 
-- <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(オブジェクト)*: メイン構成本体。追加のプロパティは含めることができません。
-  - **`output_dir`** *(文字列, 必須)*: サンプリングされたオーディオファイルの出力先ディレクトリ。
-  - **`processed_output_dir`** *(文字列, 必須)*: 処理されたサンプリングオーディオファイルの出力先ディレクトリ。
-  - **`output_prefix_format`** *(文字列)*: サンプルされたオーディオファイルのファイル名のプレフィックス。以下のプレースホルダーを使用できます: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity}, {max_velocity}, {velocity}。デフォルト: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`。
-  - **`scale_name_format`** *(文字列)*: キースケール名の表現フォーマット。例: C4 = 60を示す科学的ピッチ表記法（SPN）や、C3 = 60を示すヤマハ方式。プレースホルダーの置き換えとして機能します。次のいずれかである必要があります: `["SPN", "Yamaha"]`。デフォルト: `"Yamaha"`。
-  - **`pre_send_smf_path_list`** *(配列)*: サンプリングの前にMIDIデバイスに送信されるファイル（例：GMリセット、CCリセットなど）。デフォルト: `[]`。
-    - **アイテム** *(文字列)*: SMF(*.mid/*.midi)ファイルへのパス。
+- <a id="definitions/def_midi_config"></a>**`def_midi_config`** *(オブジェクト)*: メインの設定本体。追加のプロパティを含むことはできません。
+  - **`output_dir`** *(文字列, 必須)*: サンプリングされたオーディオファイルの出力ディレクトリ。
+  - **`processed_output_dir`** *(文字列, 必須)*: 処理されたサンプリングオーディオファイルの出力ディレクトリ。
+  - **`output_prefix_format`** *(文字列)*: サンプリングされたオーディオファイルのファイル名のプレフィックス。次のプレースホルダーが使用可能: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity}, {max_velocity}, {velocity}。デフォルト: `"{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"`。
+  - **`scale_name_format`** *(文字列)*: キースケール名の表現形式、例：C3 = 60の科学的ピッチ表記法またはC4 = 60のヤマハ方式。プレースホルダー置換として機能します。次のいずれかである必要があります: `["SPN", "Yamaha"]`。デフォルト: `"Yamaha"`。
+  - **`pre_send_smf_path_list`** *(配列)*: サンプリング前にMIDIデバイスに一度送信されるファイル（例: GMリセット, CCリセットなど）。デフォルト: `[]`。
+    - **アイテム** *(文字列)*: SMF(*.mid/*.midi)ファイルのパス。
   - **`midi_channel`** *(整数, 必須)*: サンプリング用のMIDIチャンネル番号。最小: `0`。最大: `15`。
-  - **`midi_program_change_list`** *(配列, 必須)*: サンプリング用のMIDIプログラムチェンジ(MSB, LSB, Program No)のリスト。
-    - **アイテム** *(オブジェクト)*: 追加のプロパティは含めることができません。
-      - **`msb`** *(整数)*: MIDIプログラムチェンジのMSB値。最小: `0`。最大: `127`。
-      - **`lsb`** *(整数)*: MIDIプログラムチェンジのLSB値。最小: `0`。最大: `127`。
-      - **`program`** *(整数)*: MIDIプログラムチェンジのプログラム番号。最小: `0`。最大: `127`。
-  - **`sample_zone_complex`** *(配列)*: サンプリングされたMIDIノートのキー・マッピングのリスト。
+  - **`midi_program_change_list`** *(配列, 必須)*: サンプリング用のMIDIプログラムチェンジ（MSB, LSB, プログラム番号）のリスト。
+    - **アイテム** *(オブジェクト)*: 追加のプロパティを含むことはできません。
+      - **`msb`** *(整数)*: MIDIプログラムチェンジ用のMSB値。最小: `0`。最大: `127`。
+      - **`lsb`** *(整数)*: MIDIプログラムチェンジ用のLSB値。最小: `0`。最大: `127`。
+      - **`program`** *(整数)*: MIDIプログラムチェンジ用のプログラム番号。最小: `0`。最大: `127`。
+  - **`velocity_layers_presets`** *(配列)*: ベロシティレイヤープリセットのリスト。`sample_zone_complex`および`sample_zone`で個別のレイヤーを定義するだけでなく、このプリセットをIDで参照することもできます。
+    - **アイテム**: *[#/definitions/def_velocity_layers_preset](#definitions/def_velocity_layers_preset)*を参照。
+  - **`sample_zone_complex`** *(配列)*: サンプリングされたMIDIノートのキーマップのリスト。
     - **アイテム**: *[#/definitions/def_sample_zone_complex](#definitions/def_sample_zone_complex)*を参照。
-  - **`sample_zone`** *(配列)*: サンプリングされたMIDIノートのキー・マッピングのリスト。
+  - **`sample_zone`** *(配列)*: サンプリングされたMIDIノートのキーマップのリスト。
     - **アイテム**: *[#/definitions/def_sample_zone](#definitions/def_sample_zone)*を参照。
   - **`midi_pre_wait_duration`** *(数値, 必須)*: サンプリング前の待機時間（秒単位）。`0.6`秒以上が推奨されます。
   - **`midi_note_duration`** *(数値, 必須)*: サンプリングするMIDIノートの長さ（秒単位）。
-  - **`midi_release_duration`** *(数値, 必須)*: サンプリングされたMIDIノートのリリース後の待機時間（秒単位）。整数値のみ指定可能です。
+  - **`midi_release_duration`** *(数値, 必須)*: サンプリングされたMIDIノートのリリース後の待機時間（秒単位）。整数値のみ指定可能。
 
   例:
   ```json
@@ -181,6 +183,7 @@ python -m midisampling.device
       "output_dir": "_recorded",
       "processed_output_dir": "_recorded/_processed",
       "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
+      "scale_name_format": "Yamaha",
       "pre_send_smf_path_list": [
           "path/to/GM_Reset.mid",
           "path/to/CC_Init.mid"
@@ -203,6 +206,33 @@ python -m midisampling.device
               "program": 2
           }
       ],
+      "velocity_layers_presets": [
+          {
+              "id": 0,
+              "layers": [
+                  {
+                      "min": 0,
+                      "max": 31,
+                      "send": 31
+                  },
+                  {
+                      "min": 32,
+                      "max": 63,
+                      "send": 63
+                  },
+                  {
+                      "min": 64,
+                      "max": 95,
+                      "send": 95
+                  },
+                  {
+                      "min": 96,
+                      "max": 127,
+                      "send": 127
+                  }
+              ]
+          }
+      ],
       "sample_zone": [
           {
               "key_root": {
@@ -212,17 +242,24 @@ python -m midisampling.device
               "velocity_layers": [
                   {
                       "min": 0,
-                      "max": 63,
-                      "send": 63
+                      "max": 127,
+                      "send": 127
                   }
               ]
+          },
+          {
+              "key_root": {
+                  "from": 62,
+                  "to": 63
+              },
+              "velocity_layers_preset_id": 0
           }
       ],
       "sample_zone_complex": [
           {
               "key_low": 0,
-              "key_high": 0,
-              "key_root": 40,
+              "key_high": 40,
+              "key_root": 20,
               "velocity_layers": [
                   {
                       "min": 0,
@@ -230,6 +267,12 @@ python -m midisampling.device
                       "send": 63
                   }
               ]
+          },
+          {
+              "key_low": 40,
+              "key_high": 60,
+              "key_root": 50,
+              "velocity_layers_preset_id": 0
           }
       ],
       "midi_pre_wait_duration": 0.6,
@@ -238,8 +281,8 @@ python -m midisampling.device
   }
   ```
 
-- <a id="definitions/def_midi_message_byte"></a>**`def_midi_message_byte`** *(整数)*: MIDIメッセージバイトの値(0-127)を表します。最小: `0`。最大: `127`。
-- <a id="definitions/def_integer_range"></a>**`def_integer_range`** *(オブジェクト)*: 整数値の範囲を表します。追加のプロパティは含めることができません。
+- <a id="definitions/def_midi_message_byte"></a>**`def_midi_message_byte`** *(整数)*: MIDIメッセージバイトの値（0-127）を表します。最小: `0`。最大: `127`。
+- <a id="definitions/def_integer_range"></a>**`def_integer_range`** *(オブジェクト)*: 整数の値範囲を表します。追加のプロパティを含むことはできません。
   - **`from`** *(整数, 必須)*
   - **`to`** *(整数, 必須)*
 
@@ -251,7 +294,7 @@ python -m midisampling.device
   }
   ```
 
-- <a id="definitions/def_midi_message_byte_range"></a>**`def_midi_message_byte_range`** *(オブジェクト)*: MIDIメッセージバイトの値範囲(0-127)を表します。追加のプロパティは含めることができません。
+- <a id="definitions/def_midi_message_byte_range"></a>**`def_midi_message_byte_range`** *(オブジェクト)*: MIDIメッセージバイトの値範囲（0-127）を表します。追加のプロパティを含むことはできません。
   - **`from`**: *[#/definitions/def_midi_message_byte](#definitions/def_midi_message_byte)*を参照。
   - **`to`**: *[#/definitions/def_midi_message_byte](#definitions/def_midi_message_byte)*を参照。
 
@@ -263,10 +306,12 @@ python -m midisampling.device
   }
   ```
 
-- <a id="definitions/def_midivelocity_layer"></a>**`def_midivelocity_layer`** *(オブジェクト)*: ベロシティレイヤーの設定。追加のプロパティは含めることができません。
+- <a id="definitions/def_midivelocity_layer"></a>**`def_midivelocity_layer`** *(オブジェクト)*: ベロシティレイヤーの設定。追加のプロパティを含むことはできません。
   - **`min`** *(整数, 必須)*: 最小ベロシティ値。最小: `0`。最大: `127`。
-  - **`max`** *(整数, 必須)*: 最大ベロシティ値。最小: `0`。最大: `127`。
-  - **`send`** *(整数, 必須)*: サンプリング時にMIDIデバイスに送信されるベロシティ値。最小: `0`。最大: `127`。
+  - **`max`** *(整数, 必須)*: 最大ベロシティ値。最小: `
+
+0`。最大: `127`。
+  - **`send`** *(整数, 必須)*: サンプリング時にMIDIデバイスに実際に送信されるベロシティ値。最小: `0`。最大: `127`。
 
   例:
   ```json
@@ -277,15 +322,49 @@ python -m midisampling.device
   }
   ```
 
-- <a id="definitions/def_sample_zone_complex"></a>**`def_sample_zone_complex`** *(オブジェクト)*: 複雑なサンプルゾーン設定。キー範囲とルートキーを明示的に指定する必要があります。追加のプロパティは含めることができません。
-  - **`key_low`** *(整数, 必須)*: キーマップ内の最低キー番号（ノート番号）。この値は、サードパーティのサンプラーソフトウェアとのマッピング情報として使用されることを意図しています。最小: `0`。最大: `127`。
-  - **`key_high`** *(整数, 必須)*: キーマップ内の最高キー番号（ノート番号）。この値は、サードパーティのサンプラーソフトウェアとのマッピング情報として使用されることを意図しています。最小: `0`。最大: `127`。
-  - **`key_root`** *(整数, 必須)*: キーマップのルートキー番号（ノート番号）。この値は、サンプリング時にMIDIデバイスやサードパーティのサンプラーソフトウェアに送信されるノートオンメッセージの情報として使用されることを意図しています。最小: `0`。最大: `127`。
-  - **`velocity_layers`** *(配列, 必
-
-須)*
+- <a id="definitions/def_velocity_layers_preset"></a>**`def_velocity_layers_preset`** *(オブジェクト)*: ベロシティレイヤープリセットの設定。追加のプロパティを含むことはできません。
+  - **`id`** *(整数, 必須)*: ベロシティレイヤープリセットのID。
+  - **`layers`** *(配列, 必須)*
     - **アイテム**:
         - : *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*を参照。
+
+  例:
+  ```json
+  {
+      "id": 0,
+      "layers": [
+          {
+              "min": 0,
+              "max": 31,
+              "send": 31
+          },
+          {
+              "min": 32,
+              "max": 63,
+              "send": 63
+          },
+          {
+              "min": 64,
+              "max": 95,
+              "send": 95
+          },
+          {
+              "min": 96,
+              "max": 127,
+              "send": 127
+          }
+      ]
+  }
+  ```
+
+- <a id="definitions/def_sample_zone_complex"></a>**`def_sample_zone_complex`** *(オブジェクト)*: 複雑なサンプルゾーン設定。キーレンジとルートキーは明示的に指定する必要があります。追加のプロパティを含むことはできません。
+  - **`key_low`** *(整数, 必須)*: キーマップ内の最も低いキー番号（ノート番号）。これはサードパーティのサンプラーソフトウェアとのマッピング情報として使用されることを意図しています。最小: `0`。最大: `127`。
+  - **`key_high`** *(整数, 必須)*: キーマップ内の最も高いキー番号（ノート番号）。これはサードパーティのサンプラーソフトウェアとのマッピング情報として使用されることを意図しています。最小: `0`。最大: `127`。
+  - **`key_root`** *(整数, 必須)*: キーマップ内のルートキー番号（ノート番号）。これは、サンプリング時にMIDIデバイスおよびサードパーティのサンプラーソフトウェアに送信されるノートオンメッセージの情報として使用されることを意図しています。最小: `0`。最大: `127`。
+  - **`velocity_layers`** *(配列)*
+    - **アイテム**:
+        - : *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*を参照。
+  - **`velocity_layers_preset_id`** *(整数)*: ベロシティレイヤープリセットのID。
 
   例:
   ```json
@@ -318,11 +397,21 @@ python -m midisampling.device
   }
   ```
 
-- <a id="definitions/def_sample_zone"></a>**`def_sample_zone`** *(オブジェクト)*: シンプルなサンプルゾーン設定。複雑なバージョンとは異なり、`ルートキー`だけを指定でき、個々の`key_range`の値が`ルートキー`、`最低キー`、`最高キー`として適用されます。追加のプロパティは含めることができません。
-  - **`keys`**: キーマップのルートキー番号（ノート番号）。*[#/definitions/def_midi_message_byte_range](#definitions/def_midi_message_byte_range)*を参照。
-  - **`velocity_layers`** *(配列, 必須)*
+  ```json
+  {
+      "key_low": 0,
+      "key_high": 32,
+      "key_root": 16,
+      "velocity_layers_preset_id": 0
+  }
+  ```
+
+- <a id="definitions/def_sample_zone"></a>**`def_sample_zone`** *(オブジェクト)*: シンプルなサンプルゾーンの設定。複雑なバージョンとは異なり、ルートキーのみを指定でき、個々の`key_range`の値が`ルートキー`、`ロウキー`、`ハイキー`として適用されます。追加のプロパティを含むことはできません。
+  - **`keys`**: キーマップ内のルートキー番号（ノート番号）。*[#/definitions/def_midi_message_byte_range](#definitions/def_midi_message_byte_range)*を参照。
+  - **`velocity_layers`** *(配列)*
     - **アイテム**:
         - : *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*を参照。
+  - **`velocity_layers_preset_id`** *(整数)*: ベロシティレイヤープリセットのID。
 
   例:
   ```json
@@ -353,6 +442,16 @@ python -m midisampling.device
               "send": 127
           }
       ]
+  }
+  ```
+
+  ```json
+  {
+      "keys": {
+          "from": 10,
+          "to": 100
+      },
+      "velocity_layers_preset_id": 0
   }
   ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -181,29 +181,18 @@ python -m midisampling.device
   ```json
   {
       "output_dir": "_recorded",
-      "processed_output_dir": "_recorded/_processed",
-      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
-      "scale_name_format": "Yamaha",
+      "processed_output_dir": "_processed",
+      "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{key_low}_{key_high}_{velocity}_{min_velocity}_{max_velocity}",
       "pre_send_smf_path_list": [
-          "path/to/GM_Reset.mid",
-          "path/to/CC_Init.mid"
+          "GS_Reset.mid",
+          "Reverb_Chorus_Delay_Set_0.mid"
       ],
       "midi_channel": 0,
       "midi_program_change_list": [
           {
               "msb": 0,
               "lsb": 0,
-              "program": 0
-          },
-          {
-              "msb": 0,
-              "lsb": 0,
-              "program": 1
-          },
-          {
-              "msb": 0,
-              "lsb": 0,
-              "program": 2
+              "program": 48
           }
       ],
       "velocity_layers_presets": [
@@ -233,45 +222,75 @@ python -m midisampling.device
               ]
           }
       ],
-      "sample_zone": [
+      "sample_zone_complex": [
           {
-              "key_root": {
-                  "from": 40,
-                  "to": 41
-              },
+              "key_low": 0,
+              "key_high": 32,
+              "key_root": 16,
               "velocity_layers": [
                   {
                       "min": 0,
+                      "max": 31,
+                      "send": 31
+                  },
+                  {
+                      "min": 32,
+                      "max": 63,
+                      "send": 63
+                  },
+                  {
+                      "min": 64,
+                      "max": 95,
+                      "send": 95
+                  },
+                  {
+                      "min": 96,
                       "max": 127,
                       "send": 127
                   }
               ]
           },
           {
-              "key_root": {
-                  "from": 62,
-                  "to": 63
-              },
+              "key_low": 32,
+              "key_high": 64,
+              "key_root": 48,
               "velocity_layers_preset_id": 0
           }
       ],
-      "sample_zone_complex": [
+      "sample_zone": [
           {
-              "key_low": 0,
-              "key_high": 40,
-              "key_root": 20,
+              "keys": {
+                  "from": 40,
+                  "to": 40
+              },
               "velocity_layers": [
                   {
                       "min": 0,
+                      "max": 31,
+                      "send": 31
+                  },
+                  {
+                      "min": 32,
                       "max": 63,
                       "send": 63
+                  },
+                  {
+                      "min": 64,
+                      "max": 95,
+                      "send": 95
+                  },
+                  {
+                      "min": 96,
+                      "max": 127,
+                      "send": 127
                   }
               ]
           },
           {
-              "key_low": 40,
-              "key_high": 60,
-              "key_root": 50,
+              "keys": {
+                  "from": 41,
+                  "to": 41
+              },
               "velocity_layers_preset_id": 0
           }
       ],

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -10,6 +10,17 @@
     "midi_program_change_list": [
         { "msb": 0, "lsb": 0, "program": 48}
     ],
+    "velocity_layers_presets": [
+        {
+            "id": 0,
+            "layers": [
+                { "min": 0,  "max": 31,  "send": 31 },
+                { "min": 32, "max": 63,  "send": 63 },
+                { "min": 64, "max": 95,  "send": 95 },
+                { "min": 96, "max": 127, "send": 127 }
+            ]
+        }
+    ],
     "sample_zone_complex": [
         {
             "key_low": 0,
@@ -21,6 +32,12 @@
                 { "min": 64, "max": 95,  "send": 95 },
                 { "min": 96, "max": 127, "send": 127 }
             ]
+        },
+        {
+            "key_low": 32,
+            "key_high": 64,
+            "key_root": 48,
+            "velocity_layers_preset_id": 0
         }
     ],
     "sample_zone": [
@@ -32,6 +49,10 @@
                 {"min": 64, "max": 95,  "send": 95},
                 {"min": 96, "max": 127, "send": 127}
             ]
+        },
+        {
+            "keys": {"from": 41, "to": 41},
+            "velocity_layers_preset_id": 0
         }
     ],
     "midi_pre_wait_duration": 0.6,

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -302,10 +302,18 @@
                     "maximum": 127
                 },
                 "velocity_layers": {
-                    "type": "array",
-                    "items": [
+                    "anyOf": [
                         {
-                            "$ref": "#/definitions/def_midivelocity_layer"
+                            "type": "array",
+                            "items": [
+                                {
+                                    "$ref": "#/definitions/def_midivelocity_layer"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "integer",
+                            "description": "ID of the velocity layer preset."
                         }
                     ]
                 }
@@ -340,10 +348,18 @@
                     "$ref": "#/definitions/def_midi_message_byte_range"
                 },
                 "velocity_layers": {
-                    "type": "array",
-                    "items":[
+                    "anyOf": [
                         {
-                            "$ref": "#/definitions/def_midivelocity_layer"
+                            "type": "array",
+                            "items": [
+                                {
+                                    "$ref": "#/definitions/def_midivelocity_layer"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "integer",
+                            "description": "ID of the velocity layer preset."
                         }
                     ]
                 }

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -116,55 +116,58 @@
             "examples": [
                 {
                     "output_dir": "_recorded",
-                    "processed_output_dir": "_recorded/_processed",
-                    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}",
-                    "scale_name_format": "Yamaha",
+                    "processed_output_dir": "_processed",
+                    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{key_low}_{key_high}_{velocity}_{min_velocity}_{max_velocity}",
                     "pre_send_smf_path_list": [
-                        "path/to/GM_Reset.mid",
-                        "path/to/CC_Init.mid"
+                        "GS_Reset.mid",
+                        "Reverb_Chorus_Delay_Set_0.mid"
                     ],
                     "midi_channel": 0,
                     "midi_program_change_list": [
-                        { "msb": 0, "lsb": 0, "program": 0},
-                        { "msb": 0, "lsb": 0, "program": 1},
-                        { "msb": 0, "lsb": 0, "program": 2}
+                        { "msb": 0, "lsb": 0, "program": 48}
                     ],
                     "velocity_layers_presets": [
                         {
                             "id": 0,
                             "layers": [
+                                { "min": 0,  "max": 31,  "send": 31 },
+                                { "min": 32, "max": 63,  "send": 63 },
+                                { "min": 64, "max": 95,  "send": 95 },
+                                { "min": 96, "max": 127, "send": 127 }
+                            ]
+                        }
+                    ],
+                    "sample_zone_complex": [
+                        {
+                            "key_low": 0,
+                            "key_high": 32,
+                            "key_root": 16,
+                            "velocity_layers": [
+                                { "min": 0,  "max": 31,  "send": 31 },
+                                { "min": 32, "max": 63,  "send": 63 },
+                                { "min": 64, "max": 95,  "send": 95 },
+                                { "min": 96, "max": 127, "send": 127 }
+                            ]
+                        },
+                        {
+                            "key_low": 32,
+                            "key_high": 64,
+                            "key_root": 48,
+                            "velocity_layers_preset_id": 0
+                        }
+                    ],
+                    "sample_zone": [
+                        {
+                            "keys": {"from": 40, "to": 40},
+                            "velocity_layers": [
                                 {"min": 0,  "max": 31,  "send": 31},
                                 {"min": 32, "max": 63,  "send": 63},
                                 {"min": 64, "max": 95,  "send": 95},
                                 {"min": 96, "max": 127, "send": 127}
                             ]
-                        }
-                    ],
-                    "sample_zone": [
-                        {
-                            "key_root": {"from": 40, "to": 41},
-                            "velocity_layers": [
-                                {"min": 0, "max": 127, "send": 127}
-                            ]
                         },
                         {
-                            "key_root": {"from": 62, "to": 63},
-                            "velocity_layers_preset_id": 0
-                        }
-                    ],
-                    "sample_zone_complex": [
-                        {
-                            "key_low":   0,
-                            "key_high": 40,
-                            "key_root": 20,
-                            "velocity_layers": [
-                                {"min": 0, "max": 63, "send": 63}
-                            ]
-                        },
-                        {
-                            "key_low":  40,
-                            "key_high": 60,
-                            "key_root": 50,
+                            "keys": {"from": 41, "to": 41},
                             "velocity_layers_preset_id": 0
                         }
                     ],

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -309,7 +309,7 @@
                         }
                     ]
                 },
-                "velocity_layers_ref": {
+                "velocity_layers_preset_id": {
                     "type": "integer",
                     "description": "ID of the velocity layer preset."
                 }
@@ -350,7 +350,7 @@
                         }
                     ]
                 },
-                "velocity_layers_ref": {
+                "velocity_layers_preset_id": {
                     "type": "integer",
                     "description": "ID of the velocity layer preset."
                 }

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -237,6 +237,40 @@
                 }
             ]
         },
+        "def_velocity_layers_preset": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Velocity layers preset configuration.",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "description": "ID of the velocity layer preset."
+                },
+                "layers": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "$ref": "#/definitions/def_midivelocity_layer"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "id",
+                "layers"
+            ],
+            "examples": [
+                {
+                    "id": 0,
+                    "layers": [
+                        { "min": 0,  "max": 31,  "send": 31 },
+                        { "min": 32, "max": 63,  "send": 63 },
+                        { "min": 64, "max": 95,  "send": 95 },
+                        { "min": 96, "max": 127, "send": 127 }
+                    ]
+                }
+            ]
+        },
         "def_sample_zone_complex": {
             "type": "object",
             "additionalProperties": false,

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -70,6 +70,13 @@
                         }
                     }
                 },
+                "velocity_layers_presets": {
+                    "type": "array",
+                    "description": "List of velocity layers presets. In addition to defining individual layers with `sample_zone_complex` and `sample_zone`, you can also refer to this preset by ID.",
+                    "items": {
+                        "$ref": "#/definitions/def_velocity_layers_preset"
+                    }
+                },
                 "sample_zone_complex" :{
                     "type":"array",
                     "description": "List of keymaps for the sampled MIDI notes.",

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -129,30 +129,43 @@
                         { "msb": 0, "lsb": 0, "program": 1},
                         { "msb": 0, "lsb": 0, "program": 2}
                     ],
+                    "velocity_layers_presets": [
+                        {
+                            "id": 0,
+                            "layers": [
+                                {"min": 0,  "max": 31,  "send": 31},
+                                {"min": 32, "max": 63,  "send": 63},
+                                {"min": 64, "max": 95,  "send": 95},
+                                {"min": 96, "max": 127, "send": 127}
+                            ]
+                        }
+                    ],
                     "sample_zone": [
                         {
                             "key_root": {"from": 40, "to": 41},
                             "velocity_layers": [
-                                {
-                                    "min": 0,
-                                    "max": 63,
-                                    "send": 63
-                                }
+                                {"min": 0, "max": 127, "send": 127}
                             ]
+                        },
+                        {
+                            "key_root": {"from": 62, "to": 63},
+                            "velocity_layers_preset_id": 0
                         }
                     ],
                     "sample_zone_complex": [
                         {
-                            "key_low": 0,
-                            "key_high": 0,
-                            "key_root": 40,
+                            "key_low":   0,
+                            "key_high": 40,
+                            "key_root": 20,
                             "velocity_layers": [
-                                {
-                                    "min": 0,
-                                    "max": 63,
-                                    "send": 63
-                                }
+                                {"min": 0, "max": 63, "send": 63}
                             ]
+                        },
+                        {
+                            "key_low":  40,
+                            "key_high": 60,
+                            "key_root": 50,
+                            "velocity_layers_preset_id": 0
                         }
                     ],
                     "midi_pre_wait_duration": 0.6,
@@ -330,6 +343,12 @@
                         { "min": 64, "max": 95,  "send": 95 },
                         { "min": 96, "max": 127, "send": 127 }
                     ]
+                },
+                {
+                    "key_low": 0,
+                    "key_high": 32,
+                    "key_root": 16,
+                    "velocity_layers_preset_id": 0
                 }
             ]
         },
@@ -367,6 +386,10 @@
                         { "min": 64, "max": 95,  "send": 95 },
                         { "min": 96, "max": 127, "send": 127 }
                     ]
+                },
+                {
+                    "keys": { "from": 10, "to": 100 },
+                    "velocity_layers_preset_id": 0
                 }
             ]
         }

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -302,27 +302,22 @@
                     "maximum": 127
                 },
                 "velocity_layers": {
-                    "anyOf": [
+                    "type": "array",
+                    "items": [
                         {
-                            "type": "array",
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/def_midivelocity_layer"
-                                }
-                            ]
-                        },
-                        {
-                            "type": "integer",
-                            "description": "ID of the velocity layer preset."
+                            "$ref": "#/definitions/def_midivelocity_layer"
                         }
                     ]
+                },
+                "velocity_layers_ref": {
+                    "type": "integer",
+                    "description": "ID of the velocity layer preset."
                 }
             },
             "required": [
                 "key_low",
                 "key_high",
-                "key_root",
-                "velocity_layers"
+                "key_root"
             ],
             "examples": [
                 {
@@ -348,25 +343,20 @@
                     "$ref": "#/definitions/def_midi_message_byte_range"
                 },
                 "velocity_layers": {
-                    "anyOf": [
+                    "type": "array",
+                    "items": [
                         {
-                            "type": "array",
-                            "items": [
-                                {
-                                    "$ref": "#/definitions/def_midivelocity_layer"
-                                }
-                            ]
-                        },
-                        {
-                            "type": "integer",
-                            "description": "ID of the velocity layer preset."
+                            "$ref": "#/definitions/def_midivelocity_layer"
                         }
                     ]
+                },
+                "velocity_layers_ref": {
+                    "type": "integer",
+                    "description": "ID of the velocity layer preset."
                 }
             },
             "required": [
-                "keys",
-                "velocity_layers"
+                "keys"
             ],
             "examples": [
                 {

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -322,9 +322,6 @@ class MidiConfig:
         # Velocity Layer Preset
         if "velocity_layers_presets" in config_json:
             self.velocity_layer_presets = VelocityLayerPreset.from_json(config_json["velocity_layers_presets"])
-        else:
-            self.velocity_layer_presets = []
-            print("velocity_layer_presets is empty.")
 
         # Convert to a path starting from the directory where the config file is located
         self.output_dir = _to_abs_filepath(self.config_dir, self.output_dir)

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -120,6 +120,59 @@ class VelocityLayer:
     def __str__(self) -> str:
         return f"min={self.min_velocity}, max={self.max_velocity}, send={self.send_velocity}"
 
+class VelocityLayerPreset:
+    def __init__(self, velocity_layer_preset: dict) -> None:
+        self.id: int = int(velocity_layer_preset["id"])
+        self.layers: List[VelocityLayer] = []
+
+        for x in velocity_layer_preset["layers"]:
+            self.layers.append(VelocityLayer(x))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, VelocityLayerPreset):
+            return False
+        return (
+            self.id == other.id
+            and self.layers == other.layers
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.id, self.layers))
+
+    def __str__(self) -> str:
+        return f"id={self.id}, layers[{len(self.layers)}]=[{[f"[{x}]" for x in self.layers]}]"
+
+    @classmethod
+    def from_json(cls, velocity_layer_presets: dict) -> List['VelocityLayerPreset']:
+        """
+        Create VelocityLayerPreset list from json data
+        """
+        result: List['VelocityLayerPreset'] = []
+
+        for x in velocity_layer_presets:
+            result.append(VelocityLayerPreset(x))
+
+        return result
+
+    @classmethod
+    def get_velocity_layer_preset(cls, velocity_layer_presets: List['VelocityLayerPreset'], id: int) -> 'VelocityLayerPreset':
+        """
+        Get VelocityLayerPreset by id
+
+        Parameters
+        ----------
+        velocity_layer_presets : List['VelocityLayerPreset']
+            List of VelocityLayerPreset
+
+        id : int
+            ID to search
+        """
+        for x in velocity_layer_presets:
+            if x.id == id:
+                return x
+
+        raise ValueError(f"VelocityLayerPreset not found. id={id}")
+
 class SampleZone:
     """
     Represents the smallest unit of sample zone data
@@ -147,21 +200,41 @@ class SampleZone:
         return f"key_root={self.key_root}, key_low={self.key_low}, key_high={self.key_high}, velocity_layers[{len(self.velocity_layers)}]=[{[f"[{x}]" for x in self.velocity_layers]}]"
 
     @classmethod
-    def __from_zone_complex_json(cls, zone_complex: dict) -> List['SampleZone']:
+    def __parse_velocity_layer(cls, zone: dict, presets: List[VelocityLayerPreset] ) -> List[VelocityLayer]:
+        """
+        Parse velocity layer data to list
+        """
+
+        result: List[VelocityLayer] = []
+
+        if "velocity_layers_preset_id" in zone:
+            id = int(zone["velocity_layers_preset_id"])
+            preset: VelocityLayerPreset = VelocityLayerPreset.get_velocity_layer_preset(presets, id)
+            for preset_data in preset.layers:
+                result.append(preset_data)
+
+        if "velocity_layers" in zone:
+            for x in zone["velocity_layers"]:
+                result.append(VelocityLayer(x))
+
+        return result
+
+    @classmethod
+    def __from_zone_complex_json(cls, zone_complex: dict, velocity_layers_presets: List[VelocityLayerPreset]) -> List['SampleZone']:
         """
         Create SampleZone list from json data (sample_zone_complex)
         """
         result: List['SampleZone'] = []
 
-        for key in zone_complex:
-            key_root = key["key_root"]
-            key_low  = key["key_low"]
-            key_high = key["key_high"]
+        for zone in zone_complex:
+            key_root = zone["key_root"]
+            key_low  = zone["key_low"]
+            key_high = zone["key_high"]
 
-            velocity_layers: List[VelocityLayer] = []
+            velocity_layers: List[VelocityLayer] = SampleZone.__parse_velocity_layer(zone, velocity_layers_presets)
 
-            for x in key["velocity_layers"]:
-                velocity_layers.append(VelocityLayer(x))
+            if len(velocity_layers) == 0:
+                raise ValueError(f"velocity layers is empty.")
 
             result.append(
                 SampleZone(
@@ -173,18 +246,18 @@ class SampleZone:
         return result
 
     @classmethod
-    def __from_sample_simple_json(cls, zone_simple: dict) -> List['SampleZone']:
+    def __from_sample_simple_json(cls, zone_simple: dict, velocity_layers_presets: List[VelocityLayerPreset]) -> List['SampleZone']:
         """
         Create SampleZone list from json data (sample_zone)
         """
         result: List['SampleZone'] = []
 
-        for key in zone_simple:
-            notes = _parse_midi_byte_range(key["keys"])
-            velocity_layers: List[VelocityLayer] = []
+        for zone in zone_simple:
+            notes = _parse_midi_byte_range(zone["keys"])
+            velocity_layers: List[VelocityLayer] = SampleZone.__parse_velocity_layer(zone, velocity_layers_presets)
 
-            for x in key["velocity_layers"]:
-                velocity_layers.append(VelocityLayer(x))
+            if len(velocity_layers) == 0:
+                raise ValueError(f"velocity layers is empty.")
 
             for note in notes:
                 result.append(
@@ -197,15 +270,15 @@ class SampleZone:
         return result
 
     @classmethod
-    def from_json(cls, config_json: dict) -> List['SampleZone']:
+    def from_json(cls, config_json: dict, velocity_layers_presets: List[VelocityLayerPreset]) -> List['SampleZone']:
         """
         Create SampleZone list from json data
         """
         result: List['SampleZone'] = []
         if "sample_zone_complex" in config_json:
-            result.extend(SampleZone.__from_zone_complex_json(config_json["sample_zone_complex"]))
+            result.extend(SampleZone.__from_zone_complex_json(config_json["sample_zone_complex"], velocity_layers_presets))
         if "sample_zone" in config_json:
-            result.extend(SampleZone.__from_sample_simple_json(config_json["sample_zone"]))
+            result.extend(SampleZone.__from_sample_simple_json(config_json["sample_zone"], velocity_layers_presets))
 
         return result
 
@@ -242,6 +315,7 @@ class MidiConfig:
         self.pre_send_smf_path_list: List[str]          = config_json["pre_send_smf_path_list"]
         self.midi_channel: int                          = config_json["midi_channel"]
         self.program_change_list: List[ProgramChange]   = []
+        self.velocity_layer_presets: List[VelocityLayerPreset] = []
         self.midi_pre_wait_duration: float              = config_json["midi_pre_wait_duration"]
         self.midi_note_duration: float                  = config_json["midi_note_duration"]
         self.midi_release_duration: float               = config_json["midi_release_duration"]
@@ -249,6 +323,13 @@ class MidiConfig:
         # Program Change
         for pc in config_json["midi_program_change_list"]:
             self.program_change_list.append(ProgramChange(pc))
+
+        # Velocity Layer Preset
+        if "velocity_layers_presets" in config_json:
+            self.velocity_layer_presets = VelocityLayerPreset.from_json(config_json["velocity_layers_presets"])
+        else:
+            self.velocity_layer_presets = []
+            print("velocity_layer_presets is empty.")
 
         # Convert to a path starting from the directory where the config file is located
         self.output_dir = _to_abs_filepath(self.config_dir, self.output_dir)
@@ -259,7 +340,7 @@ class MidiConfig:
             raise ValueError(f"processed_output_dir must be outside of output_dir.\n\toutput_dir={self.output_dir}\n\tprocessed_output_dir={self.processed_output_dir})")
 
         # Zone
-        self.sample_zone = SampleZone.from_json(config_json)
+        self.sample_zone = SampleZone.from_json(config_json, self.velocity_layer_presets)
 
 def validate(config_path: str) -> dict:
     with open(config_path, "r") as f:

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -291,16 +291,11 @@ class SampleZone:
         if sample_zones is None or len(sample_zones) == 0:
             return 0
 
-        root_key_count = len(sample_zones) # Root key count
-        unique_velocity_layers = list(sample_zones[0].velocity_layers)
+        total = 0
+        for zone in sample_zones:
+            total += len(zone.velocity_layers)
 
-        if len(sample_zones) == 1:
-            return len(root_key_count * unique_velocity_layers)
-
-        for zone in sample_zones[1:]:
-            unique_velocity_layers += list(zone.velocity_layers)
-
-        return root_key_count * len(set(unique_velocity_layers))
+        return total
 
 class MidiConfig:
     def __init__(self, config_path: str) -> None:


### PR DESCRIPTION
## Preset definition for velocity layer

When using velocity layers with identical contents for each zone, presets can be defined and referenced on an ID basis without having to write all of them individually.

This eliminates the need for complicated copy and paste.

## Example

Before:
If you want to adjust the velocity layer, everything needs to be modified.

```json
    "sample_zone": [
        {
            "keys": {"from": 40, "to": 40},
            "velocity_layers": [
                {"min": 0,  "max": 31,  "send": 31},
                {"min": 32, "max": 63,  "send": 63},
                {"min": 64, "max": 95,  "send": 95},
                {"min": 96, "max": 127, "send": 127}
            ]
        },
        {
            "keys": {"from": 50, "to": 80},
            "velocity_layers": [
                {"min": 0,  "max": 31,  "send": 31},
                {"min": 32, "max": 63,  "send": 63},
                {"min": 64, "max": 95,  "send": 95},
                {"min": 96, "max": 127, "send": 127}
            ]
        },
        {
            "keys": {"from": 100, "to": 120},
            "velocity_layers": [
                {"min": 0,  "max": 31,  "send": 31},
                {"min": 32, "max": 63,  "send": 63},
                {"min": 64, "max": 95,  "send": 95},
                {"min": 96, "max": 127, "send": 127}
            ]
        }
    ],

```

After:
Only the preset portion needs to be modified.
```json
    "velocity_layers_presets": [
        {
            "id": 0,
            "layers": [
                { "min": 0,  "max": 31,  "send": 31 },
                { "min": 32, "max": 63,  "send": 63 },
                { "min": 64, "max": 95,  "send": 95 },
                { "min": 96, "max": 127, "send": 127 }
            ]
        }
    ],
    "sample_zone": [
        {
            "keys": {"from": 40, "to": 40},
            "velocity_layers_preset_id": 0
        },
        {
            "keys": {"from": 50, "to": 80},
            "velocity_layers_preset_id": 0
        },
        {
            "keys": {"from": 100, "to": 120},
            "velocity_layers_preset_id": 0
        }
    ],

```

## Limitation

Preset sharing across files is not possible.
This is because it is difficult to see the scope of impact of changes when the number of files is large.