### PR TITLE
“layers” attribute name modified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
       "velocity_layers_presets": [
           {
               "id": 0,
-              "layers": [
+              "velocities": [
                   {
                       "min": 0,
                       "max": 31,
@@ -336,7 +336,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
 
 - <a id="definitions/def_velocity_layers_preset"></a>**`def_velocity_layers_preset`** *(object)*: Velocity layers preset configuration. Cannot contain additional properties.
   - **`id`** *(integer, required)*: ID of the velocity layer preset.
-  - **`layers`** *(array, required)*
+  - **`velocities`** *(array, required)*
     - **Items**:
         - : Refer to *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*.
 
@@ -344,7 +344,7 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   ```json
   {
       "id": 0,
-      "layers": [
+      "velocities": [
           {
               "min": 0,
               "max": 31,

--- a/README_ja.md
+++ b/README_ja.md
@@ -198,7 +198,7 @@ python -m midisampling.device
       "velocity_layers_presets": [
           {
               "id": 0,
-              "layers": [
+              "velocities": [
                   {
                       "min": 0,
                       "max": 31,
@@ -343,7 +343,7 @@ python -m midisampling.device
 
 - <a id="definitions/def_velocity_layers_preset"></a>**`def_velocity_layers_preset`** *(オブジェクト)*: ベロシティレイヤープリセットの設定。追加のプロパティを含むことはできません。
   - **`id`** *(整数, 必須)*: ベロシティレイヤープリセットのID。
-  - **`layers`** *(配列, 必須)*
+  - **`velocities`** *(配列, 必須)*
     - **アイテム**:
         - : *[#/definitions/def_midivelocity_layer](#definitions/def_midivelocity_layer)*を参照。
 
@@ -351,7 +351,7 @@ python -m midisampling.device
   ```json
   {
       "id": 0,
-      "layers": [
+      "velocities": [
           {
               "min": 0,
               "max": 31,

--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -13,7 +13,7 @@
     "velocity_layers_presets": [
         {
             "id": 0,
-            "layers": [
+            "velocities": [
                 { "min": 0,  "max": 31,  "send": 31 },
                 { "min": 32, "max": 63,  "send": 63 },
                 { "min": 64, "max": 95,  "send": 95 },

--- a/midisampling/appconfig/midi-config.schema.json
+++ b/midisampling/appconfig/midi-config.schema.json
@@ -129,7 +129,7 @@
                     "velocity_layers_presets": [
                         {
                             "id": 0,
-                            "layers": [
+                            "velocities": [
                                 { "min": 0,  "max": 31,  "send": 31 },
                                 { "min": 32, "max": 63,  "send": 63 },
                                 { "min": 64, "max": 95,  "send": 95 },
@@ -269,7 +269,7 @@
                     "type": "integer",
                     "description": "ID of the velocity layer preset."
                 },
-                "layers": {
+                "velocities": {
                     "type": "array",
                     "items": [
                         {
@@ -280,12 +280,12 @@
             },
             "required": [
                 "id",
-                "layers"
+                "velocities"
             ],
             "examples": [
                 {
                     "id": 0,
-                    "layers": [
+                    "velocities": [
                         { "min": 0,  "max": 31,  "send": 31 },
                         { "min": 32, "max": 63,  "send": 63 },
                         { "min": 64, "max": 95,  "send": 95 },

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -125,7 +125,7 @@ class VelocityLayerPreset:
         self.id: int = int(velocity_layer_preset["id"])
         self.layers: List[VelocityLayer] = []
 
-        for x in velocity_layer_preset["layers"]:
+        for x in velocity_layer_preset["velocities"]:
             self.layers.append(VelocityLayer(x))
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
The list was for velocity, so it was corrected to velocities.