### PR TITLE
Feature/keep wav smpl chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,12 +469,29 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
 
 ### Audio process Configuration
 
-*Structure of the post process configuration.*
+*Structure of the audio process configuration.*
 
 #### Definitions
 
-- <a id="definitions/def_postprocess_config"></a>**`def_postprocess_config`** *(object)*: Cannot contain additional properties.
-  - **`effects`** *(array)*: A list of post process configurations.
+- <a id="definitions/def_audioprocess_config"></a>**`def_audioprocess_config`** *(object)*: Cannot contain additional properties.
+  - **`keep_wav_chunks`** *(array)*: A list of wave chunk names to keep via the audio process. if not specified, all chunks will be kept. Default: `[]`.
+    - **Items** *(string)*
+
+    Examples:
+    ```json
+    [
+        "smpl"
+    ]
+    ```
+
+    ```json
+    [
+        "smpl",
+        "cue"
+    ]
+    ```
+
+  - **`effects`** *(array)*: A list of audio process configurations.
     - **Items**: Refer to *[#/definitions/def_effect](#definitions/def_effect)*.
 - <a id="definitions/def_effect"></a>**`def_effect`** *(object)*: Effect configuration. Cannot contain additional properties.
   - **`index`** *(integer, required)*: The index of the effect in the chain.
@@ -485,19 +502,26 @@ Sample files, `sampling-config.json` and `midi-config.example.json`, are include
   ```json
   [
       {
-          "index": 0,
-          "name": "normalize",
-          "params": {
-              "target_db": -10.0
-          }
-      },
-      {
-          "index": 1,
-          "name": "trim",
-          "params": {
-              "threshold_db": -65.0,
-              "min_silence_duration": 250
-          }
+          "keep_wav_chunks": [
+              "smpl"
+          ],
+          "effects": [
+              {
+                  "index": 0,
+                  "name": "normalize",
+                  "params": {
+                      "target_db": -10.0
+                  }
+              },
+              {
+                  "index": 1,
+                  "name": "trim",
+                  "params": {
+                      "threshold_db": -65.0,
+                      "min_silence_duration": 250
+                  }
+              }
+          ]
       }
   ]
   ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -474,38 +474,63 @@ python -m midisampling.device
   }
   ```
 
-### オーディオプロセス設定
+### オーディオプロセスの設定
 
 *オーディオプロセス設定の構造。*
 
 #### 定義
 
-- <a id="definitions/def_postprocess_config"></a>**`def_postprocess_config`** *(オブジェクト)*: 追加のプロパティを含むことはできません。
-  - **`effects`** *(配列)*: ポストプロセス設定のリスト。
-    - **アイテム**: *[#/definitions/def_effect](#definitions/def_effect)*を参照。
+- <a id="definitions/def_audioprocess_config"></a>**`def_audioprocess_config`** *(オブジェクト)*: 追加のプロパティを含むことはできません。
+  - **`keep_wav_chunks`** *(配列)*: オーディオプロセスで保持するWAVチャンク名のリスト。指定されていない場合、すべてのチャンクが保持されます。デフォルト: `[]`。
+    - **項目** *(文字列)*
+
+    例:
+    ```json
+    [
+        "smpl"
+    ]
+    ```
+
+    ```json
+    [
+        "smpl",
+        "cue"
+    ]
+    ```
+
+  - **`effects`** *(配列)*: オーディオプロセス設定のリスト。
+    - **項目**: *[#/definitions/def_effect](#definitions/def_effect)* を参照。
+
 - <a id="definitions/def_effect"></a>**`def_effect`** *(オブジェクト)*: エフェクト設定。追加のプロパティを含むことはできません。
   - **`index`** *(整数, 必須)*: チェーン内のエフェクトのインデックス。
   - **`name`** *(文字列, 必須)*: エフェクト名。
-  - **`params`** *(オブジェクト, 必須)*: エフェクトのパラメータの辞書。追加のプロパティを含むことができます。
+  - **`params`** *(オブジェクト, 必須)*: エフェクトのパラメータ辞書。追加のプロパティを含むことができます。
 
 #### 例
 
   ```json
   [
       {
-          "index": 0,
-          "name": "normalize",
-          "params": {
-              "target_db": -10.0
-          }
-      },
-      {
-          "index": 1,
-          "name": "trim",
-          "params": {
-              "threshold_db": -65.0,
-              "min_silence_duration": 250
-          }
+          "keep_wav_chunks": [
+              "smpl"
+          ],
+          "effects": [
+              {
+                  "index": 0,
+                  "name": "normalize",
+                  "params": {
+                      "target_db": -10.0
+                  }
+              },
+              {
+                  "index": 1,
+                  "name": "trim",
+                  "params": {
+                      "threshold_db": -65.0,
+                      "min_silence_duration": 250
+                  }
+              }
+          ]
       }
   ]
   ```

--- a/midisampling/appconfig/audioprocess-config.schema.json
+++ b/midisampling/appconfig/audioprocess-config.schema.json
@@ -7,6 +7,18 @@
             "type":"object",
             "additionalProperties": false,
             "properties": {
+                "keep_wav_chunks": {
+                    "type":"array",
+                    "description": "A list of wave chunk names to keep via the audio process",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "examples": [
+                        ["smpl"],
+                        ["smpl", "cue"]
+                    ]
+                },
                 "effects": {
                     "type": "array",
                     "description": "A list of audio process configurations",
@@ -48,19 +60,24 @@
     "examples": [
         [
             {
-                "index": 0,
-                "name": "normalize",
-                "params": {
-                    "target_db": -10.0
-                }
-            },
-            {
-                "index": 1,
-                "name": "trim",
-                "params": {
-                    "threshold_db": -65.0,
-                    "min_silence_duration": 250
-                }
+                "keep_wav_chunks": ["smpl"],
+                "effects": [
+                    {
+                        "index": 0,
+                        "name": "normalize",
+                        "params": {
+                            "target_db": -10.0
+                        }
+                    },
+                    {
+                        "index": 1,
+                        "name": "trim",
+                        "params": {
+                            "threshold_db": -65.0,
+                            "min_silence_duration": 250
+                        }
+                    }
+                ]
             }
         ]
     ]

--- a/midisampling/appconfig/audioprocess-config.schema.json
+++ b/midisampling/appconfig/audioprocess-config.schema.json
@@ -9,7 +9,7 @@
             "properties": {
                 "keep_wav_chunks": {
                     "type":"array",
-                    "description": "A list of wave chunk names to keep via the audio process",
+                    "description": "A list of wave chunk names to keep via the audio process. if not specified, all chunks will be kept.",
                     "items": {
                         "type": "string"
                     },

--- a/midisampling/appconfig/audioprocess.py
+++ b/midisampling/appconfig/audioprocess.py
@@ -33,6 +33,7 @@ class AudioProcessConfig:
     def __init__(self, config_path: str) -> None:
         config = validate(config_path)
         self.effects: List[AudioProcessInfo] = []
+        self.keep_wav_chunks: List[str] = config.get("keep_wav_chunks", [])
 
         for effect in config.get("effects", []):
             self.effects.append(
@@ -54,6 +55,7 @@ class AudioProcessConfig:
         result = "["
         for effect in self.effects:
             result += f"[{effect}], "
+        result += f"keep_wav_chunks={self.keep_wav_chunks}"
         result += "]"
 
         return result

--- a/midisampling/waveprocess/processing.py
+++ b/midisampling/waveprocess/processing.py
@@ -34,6 +34,7 @@ def process(config: AudioProcessConfig, recorded_files: List[RecordedAudioPath],
         wav_chunk_keepers: List[WavChunkKeeper] = []
 
         for x in recorded_files:
+            # Configure the export path information
             export_path = ProcessedAudioPath(
                 recorded_audio_path=x,
                 output_dir=output_dir,
@@ -52,12 +53,14 @@ def process(config: AudioProcessConfig, recorded_files: List[RecordedAudioPath],
 
             logger.debug(f"Process export path: {export_path}")
 
+        # Copy recorded files to working directory to process
         logger.info("Copy recorded files to working directory")
         for x in recorded_files:
             logger.info(f"{x.file_path}")
             x.copy_to(working_dir)
 
-        logger.info("Run processes")
+        # Procssing
+        logger.info("Processing...")
         _process_impl(
             config=config,
             process_files=process_files

--- a/midisampling/waveprocess/processing.py
+++ b/midisampling/waveprocess/processing.py
@@ -25,6 +25,7 @@ def process(config: AudioProcessConfig, recorded_files: List[RecordedAudioPath],
     if not config:
         logger.info("Process config is not set. Skip post process.")
         return
+    logger.debug(f"Process config: {config}")
 
     with tempfile.TemporaryDirectory() as working_dir:
         logger.info("Build processed audio files path list")
@@ -47,7 +48,7 @@ def process(config: AudioProcessConfig, recorded_files: List[RecordedAudioPath],
             keeper = WavChunkKeeper(
                 source_path=x.path(),
                 target_path=export_path.working_path(),
-                keep_chunk_names=["smpl"]
+                keep_chunk_names=config.keep_wav_chunks
             )
             wav_chunk_keepers.append(keeper)
 

--- a/midisampling/waveprocess/wavchunkkeeper.py
+++ b/midisampling/waveprocess/wavchunkkeeper.py
@@ -1,0 +1,152 @@
+from typing import List
+
+import struct
+
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+class WavChunkKeeper:
+    """
+    Retain the specified chunks in case the waveform processing library is not considered to retain chunks in the wav file
+    during the course of successive wav file processing.
+
+    Examples
+    --------
+    ```python
+    # initialize
+    keeper = WavChunkKeeper("source.wav", "target.wav", ['smpl'])
+
+    # read source wav file and extract chunks that are specified in keep_chunk_names
+    keeper.read()
+
+    # waveform processings and output to target.wav
+    # ...
+    # processing
+    # ...
+
+    # restore the chunks to target.wav
+    keeper.restore()
+    ```
+    """
+
+    class ChunkData:
+        def __init__(self, chunk_name: str, chunk_data: bytes, chunk_size: int, chunk_start: int):
+            self.chunk_name: str    = chunk_name
+            self.chunk_data: bytes  = chunk_data
+            self.chunk_size: int    = chunk_size
+            self.chunk_start: int   = chunk_start
+
+        def __str__(self) -> str:
+            return f"ChunkData(chunk_name={self.chunk_name}, chunk_start={self.chunk_start}, chunk_size={self.chunk_size})"
+
+    def __init__(self, source_path: str, target_path: str, keep_chunk_names: List[str] = ['smpl']):
+        """
+        Parameters
+        ----------
+        source_path : str
+            Source wav file path
+
+        target_path : str
+            Target wav file path
+
+        keep_chunk_names : List[str]
+            List of chunk names to keep (default: ['smpl'])
+        """
+        self.source_path: str               = source_path
+        self.target_path: str               = target_path
+        self.keep_chunk_names: List[str]    = keep_chunk_names
+        self.chunk_data_list: List[WavChunkKeeper.ChunkData] = []
+
+    @classmethod
+    def __exist_chunk(cls, chunk_name: str, file_bytes: bytes) -> bool:
+        chunk_index = file_bytes.find(chunk_name.encode('ascii'))
+        return chunk_index != -1
+
+    @classmethod
+    def __find_chunk(cls, chunk_name: str, file_bytes: bytes) -> ChunkData:
+        chunk_index = file_bytes.find(chunk_name.encode('ascii'))
+
+        if not WavChunkKeeper.__exist_chunk(chunk_name, file_bytes):
+            return None
+
+        # Chunk format
+        # | 'xxxx' (chunk name: 4 bytes) | chunk size (4 bytes) | data ...
+        chunk_size  = struct.unpack('<I', file_bytes[chunk_index + 4:chunk_index + 8])[0]
+        chunk_bytes = file_bytes[chunk_index:chunk_index+chunk_size + 8] # + 8: chunk name + chunk size
+
+        return WavChunkKeeper.ChunkData(
+            chunk_name=chunk_name,
+            chunk_data=chunk_bytes,
+            chunk_size=chunk_size,
+            chunk_start=chunk_index
+        )
+
+    def read(self):
+        """
+        Read source wav file and extract chunks that are specified in keep_chunk_names
+        """
+        with open(self.source_path, 'rb') as f:
+            file_bytes = f.read()
+
+            for chunk_name in self.keep_chunk_names:
+                chunk_data = WavChunkKeeper.__find_chunk(chunk_name, file_bytes)
+                if chunk_data:
+                    self.chunk_data_list.append(chunk_data)
+                    print(chunk_data)
+
+    def restore(self):
+        """
+        Restore the chunks to target_path
+        """
+        with open(self.target_path, 'rb') as f:
+            file_bytes = f.read()
+
+        # Check if the chunk to restore exists in the target file
+        exists_indexes: List[int] = []
+        for i, chunk_data in enumerate(self.chunk_data_list):
+            chunk_name  = chunk_data.chunk_name
+            chunk_index = file_bytes.find(chunk_name.encode('ascii'))
+            if chunk_index != -1:
+                exists_indexes.append(i)
+
+
+
+        # If there is no chunk to restore, do nothing
+        if len(exists_indexes) == 0:
+            return
+
+        with open(self.target_path, 'wb') as f:
+
+            riff_index = file_bytes.find(b'RIFF')
+            fmt_index  = file_bytes.find(b'fmt ')
+            data_start = fmt_index + 8 + struct.unpack('<I', file_bytes[fmt_index + 4:fmt_index + 8])[0]
+
+            f.write(file_bytes[:data_start])
+
+            for i in self.chunk_data_list:
+                if WavChunkKeeper.__exist_chunk(i.chunk_name, file_bytes):
+                    continue
+
+                f.write(i.chunk_data)
+
+            f.write(file_bytes[data_start:])
+
+            # Update RIFF chunk size
+            riff_size = len(file_bytes) - 8
+            f.seek(4)
+            f.write(struct.pack('<I', riff_size))
+
+
+from pydub import AudioSegment
+
+input  = "C:\\UserData\\Develop\\Project\\OSS\\midi-sampling\\examples\\_processed\\40_40_40_127_96_127.wav"
+output = "C:\\UserData\\Develop\\Project\\OSS\\midi-sampling\\examples\\_processed\\40_40_40_127_96_127_zzz.wav"
+
+audio = AudioSegment.from_file(input, format='wav')
+processed_audio = audio + 5
+processed_audio.export(output, format='wav')
+
+keeper = WavChunkKeeper(input, output, ['smpl'])
+keeper.read()
+keeper.restore()


### PR DESCRIPTION
wavファイル処理の過程でサードパーティライブラリによっては必須のチャンク以外破棄してしまう実装があるため、 `smpl` チャンクなど保持しておきたいチャンクを指定できるように対応した。

Since some third-party libraries discard chunks other than the essential ones in the wav file processing process, we added support for specifying chunks to be retained, such as `smpl` chunks.