### PR TITLE
Refactor/guard overwrite recording files

### DIFF
--- a/midisampling/__main__.py
+++ b/midisampling/__main__.py
@@ -27,6 +27,7 @@ def main():
     parser.add_argument("postprocess_config_path", help="Path to the process configuration file for post processing.", default=None, nargs="?")
     parser.add_argument("-l", "--log-file", help="Path to save the log file.")
     parser.add_argument("-rw", "--overwrite-recorded", help="Overwrite recorded file if it exists.", action="store_true", default=False)
+    parser.add_argument("--dry-run", help="Dry run the sampling process.", action="store_true", default=False)
 
     args = parser.parse_args()
 
@@ -38,6 +39,23 @@ def main():
 
     init_logging_from_config(logfile_path=logfile_path, verbose=args.verbose)
     _log_system_info()
+
+    samplig_args = SamplingArguments(
+        sampling_config_path=args.sampling_config_path,
+        midi_config_path=args.midi_config_path,
+        postprocess_config_path=args.postprocess_config_path,
+        overwrite_recorded=args.overwrite_recorded
+    )
+
+    if args.dry_run:
+        from midisampling.dryrun import execute as dry_run
+        try:
+            dry_run(args=samplig_args)
+        except Exception as e:
+            logger.error(e, exc_info=True)
+        finally:
+            logger.debug("End")
+        return
 
     from midisampling.sampling import main as sampling_main
     try:

--- a/midisampling/__main__.py
+++ b/midisampling/__main__.py
@@ -6,6 +6,8 @@ from logging import getLogger
 
 from midisampling.logging_management import init_logging_from_config
 
+from midisampling.sampling import SamplingArguments
+
 THIS_SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 logger = getLogger(__name__)
 
@@ -39,12 +41,7 @@ def main():
 
     from midisampling.sampling import main as sampling_main
     try:
-        sampling_main(
-            sampling_config_path=args.sampling_config_path,
-            midi_config_path=args.midi_config_path,
-            postprocess_config_path=args.postprocess_config_path,
-            over_write_recorded=args.overwrite_recorded
-        )
+        sampling_main(args=samplig_args)
     except Exception as e:
         logger.error(e, exc_info=True)
     finally:

--- a/midisampling/__main__.py
+++ b/midisampling/__main__.py
@@ -24,6 +24,7 @@ def main():
     parser.add_argument("midi_config_path", help="Path to the MIDI configuration file.")
     parser.add_argument("postprocess_config_path", help="Path to the process configuration file for post processing.", default=None, nargs="?")
     parser.add_argument("-l", "--log-file", help="Path to save the log file.")
+    parser.add_argument("-rw", "--overwrite-recorded", help="Overwrite recorded file if it exists.", action="store_true", default=False)
 
     args = parser.parse_args()
 
@@ -41,7 +42,8 @@ def main():
         sampling_main(
             sampling_config_path=args.sampling_config_path,
             midi_config_path=args.midi_config_path,
-            postprocess_config_path=args.postprocess_config_path
+            postprocess_config_path=args.postprocess_config_path,
+            over_write_recorded=args.overwrite_recorded
         )
     except Exception as e:
         logger.error(e, exc_info=True)

--- a/midisampling/dryrun.py
+++ b/midisampling/dryrun.py
@@ -1,0 +1,73 @@
+from typing import List
+import math
+import os
+import time
+from logging import getLogger
+
+from midisampling.appconfig.sampling import SamplingConfig
+from midisampling.appconfig.sampling import load as load_samplingconfig
+
+from midisampling.appconfig.midi import MidiConfig, SampleZone
+from midisampling.appconfig.midi import load as load_midi_config
+
+from midisampling.exportpath import RecordedAudioPath, ProcessedAudioPath
+
+from midisampling.sampling import SamplingArguments, expand_path_placeholder
+
+
+THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+logger = getLogger(__name__)
+
+def execute(args: SamplingArguments):
+    """
+    Dry run the sampling process. This will load configuration files.
+    But print out the sampling process without actually doing it.
+    """
+
+    #---------------------------------------------------------------------------
+    # Load config values
+    #---------------------------------------------------------------------------
+    sampling_config: SamplingConfig = load_samplingconfig(args.sampling_config_path)
+    midi_config: MidiConfig = load_midi_config(args.midi_config_path)
+
+    total_sampling_count = len(midi_config.program_change_list) * SampleZone.get_total_sample_count(midi_config.sample_zone)
+    process_count = 1
+
+    recorded_path_list: List[RecordedAudioPath] = []
+
+    try:
+        for program in midi_config.program_change_list:
+            for zone in midi_config.sample_zone:
+                for velocity in zone.velocity_layers:
+
+                    output_file_path = expand_path_placeholder(
+                        format_string=midi_config.output_prefix_format,
+                        pc_msb=program.msb,
+                        pc_lsb=program.lsb,
+                        pc_value=program.program,
+                        key_root=zone.key_root,
+                        key_low=zone.key_low,
+                        key_high=zone.key_high,
+                        min_velocity=velocity.min_velocity,
+                        max_velocity=velocity.max_velocity,
+                        velocity=velocity.send_velocity,
+                        use_scale_spn_format=midi_config.scale_name_format == "SPN"
+                    )
+
+                    export_path = RecordedAudioPath(base_dir=midi_config.output_dir, file_path=output_file_path + ".wav")
+
+                    logger.info(f"[{process_count:4d}/{total_sampling_count:4d}] Export recorded data to: {export_path.path()}")
+
+                    # Check recorded file has already existed
+                    # If over_write_recorded is False, raise exception
+                    if not args.overwrite_recorded and export_path in recorded_path_list:
+                        raise FileExistsError(f"Recorded file already exists. Duplecate sample zone(s) {export_path.path()}")
+
+                    recorded_path_list.append(export_path)
+                    process_count += 1
+
+        logger.info(f"Dry run successed.")
+
+    except Exception as e:
+        logger.error(f"Error occurred: {e}")
+        logger.error(f"Dry run failed.")

--- a/midisampling/sampling.py
+++ b/midisampling/sampling.py
@@ -80,7 +80,7 @@ def expand_path_placeholder(format_string:str, pc_msb:int, pc_lsb:int, pc_value,
 
     return dynamic_format.format(format_string=format_string, data=format_value)
 
-def main(sampling_config_path: str, midi_config_path: str, postprocess_config_path:str = None) -> None:
+def main(sampling_config_path: str, midi_config_path: str, postprocess_config_path:str = None, over_write_recorded: bool = False) -> None:
 
     #---------------------------------------------------------------------------
     # Load config values
@@ -217,6 +217,15 @@ def main(sampling_config_path: str, midi_config_path: str, postprocess_config_pa
 
                     export_path = RecordedAudioPath(base_dir=output_dir, file_path=output_file_path + ".wav")
                     export_path.makedirs()
+
+                    logger.debug(f"  -> Export recorded data to: {export_path.path()}")
+
+                    # Check recorded file has already existed
+                    # If over_write_recorded is False, raise exception
+                    if not over_write_recorded and os.path.exists(export_path.path()):
+                        logger.error(f"Recorded file already exists: {export_path.path()}")
+                        logger.error("If you want to overwrite anyway, please set overwrite option.")
+                        raise FileExistsError(f"Recorded file already exists: {export_path.path()}")
 
                     audio_device.export_audio(export_path.path())
 

--- a/midisampling/sampling.py
+++ b/midisampling/sampling.py
@@ -33,6 +33,17 @@ import midisampling.notenumber as notenumber_util
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 logger = getLogger(__name__)
 
+
+class SamplingArguments:
+    """
+    Composite of sampling, MIDI, and post process configurations.
+    """
+    def __init__(self, sampling_config_path: str, midi_config_path: str, postprocess_config_path:str = None, overwrite_recorded: bool = False):
+        self.sampling_config_path = sampling_config_path
+        self.midi_config_path = midi_config_path
+        self.postprocess_config_path = postprocess_config_path
+        self.overwrite_recorded = overwrite_recorded
+
 def expand_path_placeholder(format_string:str, pc_msb:int, pc_lsb:int, pc_value, key_root: int, key_low: int, key_high: int, min_velocity:int, max_velocity:int, velocity: int, use_scale_spn_format: bool):
     """
     Expand placeholders in format_string with given values
@@ -80,17 +91,17 @@ def expand_path_placeholder(format_string:str, pc_msb:int, pc_lsb:int, pc_value,
 
     return dynamic_format.format(format_string=format_string, data=format_value)
 
-def main(sampling_config_path: str, midi_config_path: str, postprocess_config_path:str = None, over_write_recorded: bool = False) -> None:
+def main(args: SamplingArguments) -> None:
 
     #---------------------------------------------------------------------------
     # Load config values
     #---------------------------------------------------------------------------
-    sampling_config: SamplingConfig = load_samplingconfig(sampling_config_path)
-    midi_config: MidiConfig = load_midi_config(midi_config_path)
+    sampling_config: SamplingConfig = load_samplingconfig(args.sampling_config_path)
+    midi_config: MidiConfig = load_midi_config(args.midi_config_path)
 
     postprocess_config: AudioProcessConfig = None
-    if postprocess_config_path:
-        postprocess_config = AudioProcessConfig(postprocess_config_path)
+    if args.postprocess_config_path:
+        postprocess_config = AudioProcessConfig(args.postprocess_config_path)
         validate_process_config(postprocess_config)
 
     #---------------------------------------------------------------------------
@@ -222,7 +233,7 @@ def main(sampling_config_path: str, midi_config_path: str, postprocess_config_pa
 
                     # Check recorded file has already existed
                     # If over_write_recorded is False, raise exception
-                    if not over_write_recorded and os.path.exists(export_path.path()):
+                    if not args.overwrite_recorded and os.path.exists(export_path.path()):
                         logger.error(f"Recorded file already exists: {export_path.path()}")
                         logger.error("If you want to overwrite anyway, please set overwrite option.")
                         raise FileExistsError(f"Recorded file already exists: {export_path.path()}")


### PR DESCRIPTION
- If a file already recorded exists, it now behaves as an error if the overwrite option is not enabled.
  - Can occur when sample zones are inadvertently described as duplicates in the MIDI sampling settings
- Dry-run feature implemented to pre-verify sample zone overlap


- 既に録音済みのファイルが存在していた場合、上書きオプションが有効でない場合はエラーとして振る舞うようにした。
  - MIDIサンプリング設定で誤ってサンプルゾーンが重複して記述していた場合に発生しうる
- サンプルゾーン重複を事前に検証するためのドライラン機能を実装