### PR TITLE
Divided json schema files for midi-config

### DIFF
--- a/midisampling/appconfig/json.schema.files/midi/integer-range.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/integer-range.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Represents an integer value range",
+    "properties": {
+        "from": {
+            "type": "integer"
+        },
+        "to": {
+            "type": "integer"
+        }
+    },
+    "required": [
+        "from",
+        "to"
+    ],
+    "examples": [
+        { "from": 10, "to": 100 }
+    ]
+}

--- a/midisampling/appconfig/json.schema.files/midi/midi-channel.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-channel.schema.json
@@ -1,7 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "integer",
-    "additionalProperties": false,
     "description": "MIDI channel number",
     "minimum": 0,
     "maximum": 15

--- a/midisampling/appconfig/json.schema.files/midi/midi-channel.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-channel.schema.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "integer",
+    "additionalProperties": false,
+    "description": "MIDI channel number",
+    "minimum": 0,
+    "maximum": 15
+}

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -190,65 +190,7 @@
             "$ref": "midi-velocity-layer-preset.schema.json"
         },
         "def_sample_zone_complex": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "Sample zone complex configuration. The key range, root key, must be specified explicitly.",
-            "properties": {
-                "key_low": {
-                    "type": "integer",
-                    "description": "Lowest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
-                    "minimum": 0,
-                    "maximum": 127
-                },
-                "key_high": {
-                    "type": "integer",
-                    "description": "Highest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
-                    "minimum": 0,
-                    "maximum": 127
-                },
-                "key_root": {
-                    "type": "integer",
-                    "description": "Root key number (note number) in the keymap. This value is intended to be used as information for mapping note-on messages sent to MIDI devices and third-party sampler software when sampling.",
-                    "minimum": 0,
-                    "maximum": 127
-                },
-                "velocity_layers": {
-                    "type": "array",
-                    "items": [
-                        {
-                            "$ref": "#/definitions/def_midivelocity_layer"
-                        }
-                    ]
-                },
-                "velocity_layers_preset_id": {
-                    "type": "integer",
-                    "description": "ID of the velocity layer preset."
-                }
-            },
-            "required": [
-                "key_low",
-                "key_high",
-                "key_root"
-            ],
-            "examples": [
-                {
-                    "key_low": 0,
-                    "key_high": 32,
-                    "key_root": 16,
-                    "velocity_layers": [
-                        { "min": 0,  "max": 31,  "send": 31 },
-                        { "min": 32, "max": 63,  "send": 63 },
-                        { "min": 64, "max": 95,  "send": 95 },
-                        { "min": 96, "max": 127, "send": 127 }
-                    ]
-                },
-                {
-                    "key_low": 0,
-                    "key_high": 32,
-                    "key_root": 16,
-                    "velocity_layers_preset_id": 0
-                }
-            ]
+            "$ref": "sample-zone-complex.schema.json"
         },
         "def_sample_zone": {
             "type": "object",

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -184,41 +184,7 @@
             "$ref": "midi-message-byte-range.schema.json"
         },
         "def_midivelocity_layer": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "Velocity layer configuration",
-            "properties": {
-                "min": {
-                    "type": "integer",
-                    "description": "Minimum velocity value.",
-                    "minimum": 0,
-                    "maximum": 127
-                },
-                "max": {
-                    "type": "integer",
-                    "description": "Maximum velocity value.",
-                    "minimum": 0,
-                    "maximum": 127
-                },
-                "send": {
-                    "type": "integer",
-                    "description": "Velocity value actually sent to the MIDI device when sampling.",
-                    "minimum": 0,
-                    "maximum": 127
-                }
-            },
-            "required": [
-                "min",
-                "max",
-                "send"
-            ],
-            "examples": [
-                {
-                    "min": 0,
-                    "max": 127,
-                    "send": 127
-                }
-            ]
+            "$ref": "midi-velocity-layer.schema.json"
         },
         "def_velocity_layers_preset": {
             "type": "object",

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -37,10 +37,7 @@
                     "default": []
                 },
                 "midi_channel": {
-                    "type": "integer",
-                    "description": "MIDI channel number for sampling.",
-                    "minimum": 0,
-                    "maximum": 15
+                    "$ref": "midi-channel.schema.json"
                 },
                 "midi_program_change_list" : {
                     "type":"array",

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -43,28 +43,7 @@
                     "type":"array",
                     "description": "List of MIDI program change (MSB, LSB, Program No) for sampling.",
                     "items": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "msb": {
-                                "type": "integer",
-                                "description": "MSB value for the MIDI program change.",
-                                "minimum": 0,
-                                "maximum": 127
-                            },
-                            "lsb": {
-                                "type": "integer",
-                                "description": "LSB value for the MIDI program change.",
-                                "minimum": 0,
-                                "maximum": 127
-                            },
-                            "program": {
-                                "type": "integer",
-                                "description": "Program number for the MIDI program change.",
-                                "minimum": 0,
-                                "maximum": 127
-                            }
-                        }
+                        "$ref": "midi-program-change.schema.json"
                     }
                 },
                 "velocity_layers_presets": {

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -50,21 +50,21 @@
                     "type": "array",
                     "description": "List of velocity layers presets. In addition to defining individual layers with `sample_zone_complex` and `sample_zone`, you can also refer to this preset by ID.",
                     "items": {
-                        "$ref": "#/definitions/def_velocity_layers_preset"
+                        "$ref": "midi-velocity-layer-preset.schema.json"
                     }
                 },
                 "sample_zone_complex" :{
                     "type":"array",
                     "description": "List of keymaps for the sampled MIDI notes.",
                     "items": {
-                        "$ref": "#/definitions/def_sample_zone_complex"
+                        "$ref": "sample-zone-complex.schema.json"
                     }
                 },
                 "sample_zone" :{
                     "type":"array",
                     "description": "List of keymaps for the sampled MIDI notes.",
                     "items": {
-                        "$ref": "#/definitions/def_sample_zone"
+                        "$ref": "sample-zone.schema.json"
                     }
                 },
                 "midi_pre_wait_duration": {
@@ -152,27 +152,6 @@
                     "midi_release_duration": 1.5
                 }
             ]
-        },
-        "def_midi_message_byte": {
-            "$ref": "midi-message-byte.schema.json"
-        },
-        "def_integer_range": {
-            "$ref": "integer-range.schema.json"
-        },
-        "def_midi_message_byte_range": {
-            "$ref": "midi-message-byte-range.schema.json"
-        },
-        "def_midivelocity_layer": {
-            "$ref": "midi-velocity-layer.schema.json"
-        },
-        "def_velocity_layers_preset": {
-            "$ref": "midi-velocity-layer-preset.schema.json"
-        },
-        "def_sample_zone_complex": {
-            "$ref": "sample-zone-complex.schema.json"
-        },
-        "def_sample_zone": {
-            "$ref": "sample-zone.schema.json"
         }
     },
     "type": "object",

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -187,38 +187,7 @@
             "$ref": "midi-velocity-layer.schema.json"
         },
         "def_velocity_layers_preset": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "Velocity layers preset configuration.",
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "description": "ID of the velocity layer preset."
-                },
-                "velocities": {
-                    "type": "array",
-                    "items": [
-                        {
-                            "$ref": "#/definitions/def_midivelocity_layer"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "id",
-                "velocities"
-            ],
-            "examples": [
-                {
-                    "id": 0,
-                    "velocities": [
-                        { "min": 0,  "max": 31,  "send": 31 },
-                        { "min": 32, "max": 63,  "send": 63 },
-                        { "min": 64, "max": 95,  "send": 95 },
-                        { "min": 96, "max": 127, "send": 127 }
-                    ]
-                }
-            ]
+            "$ref": "midi-velocity-layer-preset.schema.json"
         },
         "def_sample_zone_complex": {
             "type": "object",

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -2,159 +2,151 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MIDI Sampling Configuration",
     "description": "Structure of the MIDI sampling configuration.",
-    "definitions": {
-        "def_midi_config": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "The main configuration body",
-            "properties": {
-                "output_dir": {
-                    "type": "string",
-                    "description": "Directory for the output of the sampled audio files."
-                },
-                "processed_output_dir": {
-                    "type": "string",
-                    "description": "Directory for the output of processed sampled audio files."
-                },
-                "output_prefix_format": {
-                    "type": "string",
-                    "description": "Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity} {max_velocity} {velocity}.",
-                    "default": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"
-                },
-                "scale_name_format": {
-                    "type": "string",
-                    "description": "Format for representation by keyscale name, e.g. Scientific pitch notation with C3 = 60 or Yamaha method with C4 = 60. Works as a placeholder replacement.",
-                    "enum": ["SPN", "Yamaha"],
-                    "default": "Yamaha"
-                },
-                "pre_send_smf_path_list" : {
-                    "type":"array",
-                    "description": "These file(s) will be sent to the MIDI device before sampling once e.g. GM Reset, CC Reset, etc.",
-                    "items": {
-                        "type": "string",
-                        "description": "Path to the SMF(*.mid/*.midi) file(s)"
-                    },
-                    "default": []
-                },
-                "midi_channel": {
-                    "$ref": "midi-channel.schema.json"
-                },
-                "midi_program_change_list" : {
-                    "type":"array",
-                    "description": "List of MIDI program change (MSB, LSB, Program No) for sampling.",
-                    "items": {
-                        "$ref": "midi-program-change.schema.json"
-                    }
-                },
-                "velocity_layers_presets": {
-                    "type": "array",
-                    "description": "List of velocity layers presets. In addition to defining individual layers with `sample_zone_complex` and `sample_zone`, you can also refer to this preset by ID.",
-                    "items": {
-                        "$ref": "midi-velocity-layer-preset.schema.json"
-                    }
-                },
-                "sample_zone_complex" :{
-                    "type":"array",
-                    "description": "List of keymaps for the sampled MIDI notes.",
-                    "items": {
-                        "$ref": "sample-zone-complex.schema.json"
-                    }
-                },
-                "sample_zone" :{
-                    "type":"array",
-                    "description": "List of keymaps for the sampled MIDI notes.",
-                    "items": {
-                        "$ref": "sample-zone.schema.json"
-                    }
-                },
-                "midi_pre_wait_duration": {
-                    "type": "number",
-                    "description": "Pre-wait time (in seconds) before sampling. A value of `0.6` or higher is recommended."
-                },
-                "midi_note_duration": {
-                    "type": "number",
-                    "description": "Length of the MIDI note to be sampled (in seconds)."
-                },
-                "midi_release_duration": {
-                    "type": "number",
-                    "description": "Wait time (in seconds) after the release of the sampled MIDI note. Only integer values can be specified."
-                }
-            },
-            "required": [
-                "output_dir",
-                "processed_output_dir",
-                "midi_channel",
-                "midi_program_change_list",
-                "midi_pre_wait_duration",
-                "midi_note_duration",
-                "midi_release_duration"
-            ],
-            "examples": [
-                {
-                    "output_dir": "_recorded",
-                    "processed_output_dir": "_processed",
-                    "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{key_low}_{key_high}_{velocity}_{min_velocity}_{max_velocity}",
-                    "pre_send_smf_path_list": [
-                        "GS_Reset.mid",
-                        "Reverb_Chorus_Delay_Set_0.mid"
-                    ],
-                    "midi_channel": 0,
-                    "midi_program_change_list": [
-                        { "msb": 0, "lsb": 0, "program": 48}
-                    ],
-                    "velocity_layers_presets": [
-                        {
-                            "id": 0,
-                            "velocities": [
-                                { "min": 0,  "max": 31,  "send": 31 },
-                                { "min": 32, "max": 63,  "send": 63 },
-                                { "min": 64, "max": 95,  "send": 95 },
-                                { "min": 96, "max": 127, "send": 127 }
-                            ]
-                        }
-                    ],
-                    "sample_zone_complex": [
-                        {
-                            "key_low": 0,
-                            "key_high": 32,
-                            "key_root": 16,
-                            "velocity_layers": [
-                                { "min": 0,  "max": 31,  "send": 31 },
-                                { "min": 32, "max": 63,  "send": 63 },
-                                { "min": 64, "max": 95,  "send": 95 },
-                                { "min": 96, "max": 127, "send": 127 }
-                            ]
-                        },
-                        {
-                            "key_low": 32,
-                            "key_high": 64,
-                            "key_root": 48,
-                            "velocity_layers_preset_id": 0
-                        }
-                    ],
-                    "sample_zone": [
-                        {
-                            "keys": {"from": 40, "to": 40},
-                            "velocity_layers": [
-                                {"min": 0,  "max": 31,  "send": 31},
-                                {"min": 32, "max": 63,  "send": 63},
-                                {"min": 64, "max": 95,  "send": 95},
-                                {"min": 96, "max": 127, "send": 127}
-                            ]
-                        },
-                        {
-                            "keys": {"from": 41, "to": 41},
-                            "velocity_layers_preset_id": 0
-                        }
-                    ],
-                    "midi_pre_wait_duration": 0.6,
-                    "midi_note_duration": 2.5,
-                    "midi_release_duration": 1.5
-                }
-            ]
-        }
-    },
     "type": "object",
     "additionalProperties": false,
-    "$ref": "#/definitions/def_midi_config"
+    "properties": {
+        "output_dir": {
+            "type": "string",
+            "description": "Directory for the output of the sampled audio files."
+        },
+        "processed_output_dir": {
+            "type": "string",
+            "description": "Directory for the output of processed sampled audio files."
+        },
+        "output_prefix_format": {
+            "type": "string",
+            "description": "Prefix for the filenames of the sampled audio files. The following placeholders can be used: {pc_msb}, {pc_lsb}, {pc}, {key_root}, {key_low}, {key_high}, {key_root_scale}, {key_low_scale}, {key_high_scale}, {min_velocity} {max_velocity} {velocity}.",
+            "default": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{velocity}"
+        },
+        "scale_name_format": {
+            "type": "string",
+            "description": "Format for representation by keyscale name, e.g. Scientific pitch notation with C3 = 60 or Yamaha method with C4 = 60. Works as a placeholder replacement.",
+            "enum": ["SPN", "Yamaha"],
+            "default": "Yamaha"
+        },
+        "pre_send_smf_path_list" : {
+            "type":"array",
+            "description": "These file(s) will be sent to the MIDI device before sampling once e.g. GM Reset, CC Reset, etc.",
+            "items": {
+                "type": "string",
+                "description": "Path to the SMF(*.mid/*.midi) file(s)"
+            },
+            "default": []
+        },
+        "midi_channel": {
+            "$ref": "midi-channel.schema.json"
+        },
+        "midi_program_change_list" : {
+            "type":"array",
+            "description": "List of MIDI program change (MSB, LSB, Program No) for sampling.",
+            "items": {
+                "$ref": "midi-program-change.schema.json"
+            }
+        },
+        "velocity_layers_presets": {
+            "type": "array",
+            "description": "List of velocity layers presets. In addition to defining individual layers with `sample_zone_complex` and `sample_zone`, you can also refer to this preset by ID.",
+            "items": {
+                "$ref": "midi-velocity-layer-preset.schema.json"
+            }
+        },
+        "sample_zone_complex" :{
+            "type":"array",
+            "description": "List of keymaps for the sampled MIDI notes.",
+            "items": {
+                "$ref": "sample-zone-complex.schema.json"
+            }
+        },
+        "sample_zone" :{
+            "type":"array",
+            "description": "List of keymaps for the sampled MIDI notes.",
+            "items": {
+                "$ref": "sample-zone.schema.json"
+            }
+        },
+        "midi_pre_wait_duration": {
+            "type": "number",
+            "description": "Pre-wait time (in seconds) before sampling. A value of `0.6` or higher is recommended."
+        },
+        "midi_note_duration": {
+            "type": "number",
+            "description": "Length of the MIDI note to be sampled (in seconds)."
+        },
+        "midi_release_duration": {
+            "type": "number",
+            "description": "Wait time (in seconds) after the release of the sampled MIDI note. Only integer values can be specified."
+        }
+    },
+    "required": [
+        "output_dir",
+        "processed_output_dir",
+        "midi_channel",
+        "midi_program_change_list",
+        "midi_pre_wait_duration",
+        "midi_note_duration",
+        "midi_release_duration"
+    ],
+    "examples": [
+        {
+            "output_dir": "_recorded",
+            "processed_output_dir": "_processed",
+            "output_prefix_format": "{pc}_{pc_msb}_{pc_lsb}_{key_root}_{key_low}_{key_high}_{velocity}_{min_velocity}_{max_velocity}",
+            "pre_send_smf_path_list": [
+                "GS_Reset.mid",
+                "Reverb_Chorus_Delay_Set_0.mid"
+            ],
+            "midi_channel": 0,
+            "midi_program_change_list": [
+                { "msb": 0, "lsb": 0, "program": 48}
+            ],
+            "velocity_layers_presets": [
+                {
+                    "id": 0,
+                    "velocities": [
+                        { "min": 0,  "max": 31,  "send": 31 },
+                        { "min": 32, "max": 63,  "send": 63 },
+                        { "min": 64, "max": 95,  "send": 95 },
+                        { "min": 96, "max": 127, "send": 127 }
+                    ]
+                }
+            ],
+            "sample_zone_complex": [
+                {
+                    "key_low": 0,
+                    "key_high": 32,
+                    "key_root": 16,
+                    "velocity_layers": [
+                        { "min": 0,  "max": 31,  "send": 31 },
+                        { "min": 32, "max": 63,  "send": 63 },
+                        { "min": 64, "max": 95,  "send": 95 },
+                        { "min": 96, "max": 127, "send": 127 }
+                    ]
+                },
+                {
+                    "key_low": 32,
+                    "key_high": 64,
+                    "key_root": 48,
+                    "velocity_layers_preset_id": 0
+                }
+            ],
+            "sample_zone": [
+                {
+                    "keys": {"from": 40, "to": 40},
+                    "velocity_layers": [
+                        {"min": 0,  "max": 31,  "send": 31},
+                        {"min": 32, "max": 63,  "send": 63},
+                        {"min": 64, "max": 95,  "send": 95},
+                        {"min": 96, "max": 127, "send": 127}
+                    ]
+                },
+                {
+                    "keys": {"from": 41, "to": 41},
+                    "velocity_layers_preset_id": 0
+                }
+            ],
+            "midi_pre_wait_duration": 0.6,
+            "midi_note_duration": 2.5,
+            "midi_release_duration": 1.5
+        }
+    ]
 }

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -193,45 +193,7 @@
             "$ref": "sample-zone-complex.schema.json"
         },
         "def_sample_zone": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "A simple configuration of sample zone. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`.",
-            "properties": {
-                "keys": {
-                    "description": "Root key number (note number) in the keymap.",
-                    "$ref": "#/definitions/def_midi_message_byte_range"
-                },
-                "velocity_layers": {
-                    "type": "array",
-                    "items": [
-                        {
-                            "$ref": "#/definitions/def_midivelocity_layer"
-                        }
-                    ]
-                },
-                "velocity_layers_preset_id": {
-                    "type": "integer",
-                    "description": "ID of the velocity layer preset."
-                }
-            },
-            "required": [
-                "keys"
-            ],
-            "examples": [
-                {
-                    "keys": { "from": 10, "to": 100 },
-                    "velocity_layers": [
-                        { "min": 0,  "max": 31,  "send": 31 },
-                        { "min": 32, "max": 63,  "send": 63 },
-                        { "min": 64, "max": 95,  "send": 95 },
-                        { "min": 96, "max": 127, "send": 127 }
-                    ]
-                },
-                {
-                    "keys": { "from": 10, "to": 100 },
-                    "velocity_layers_preset_id": 0
-                }
-            ]
+            "$ref": "sample-zone.schema.json"
         }
     },
     "type": "object",

--- a/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-config.schema.json
@@ -175,50 +175,13 @@
             ]
         },
         "def_midi_message_byte": {
-            "type": "integer",
-            "description": "Represents the value of the MIDI message byte (0-127)",
-            "minimum": 0,
-            "maximum": 127
+            "$ref": "midi-message-byte.schema.json"
         },
         "def_integer_range": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "Represents an integer value range",
-            "properties": {
-                "from": {
-                    "type": "integer"
-                },
-                "to": {
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "from",
-                "to"
-            ],
-            "examples": [
-                { "from": 10, "to": 100 }
-            ]
+            "$ref": "integer-range.schema.json"
         },
         "def_midi_message_byte_range": {
-            "type": "object",
-            "additionalProperties": false,
-            "description": "Represents the value range (0-127) of the MIDI message byte",
-            "properties": {
-                "from": {
-                    "$ref": "#/definitions/def_midi_message_byte"
-                },
-                "to": {
-                    "$ref": "#/definitions/def_midi_message_byte"
-                }
-            },
-            "required": [
-                "from",
-                "to"
-            ],
-            "examples": [
-                { "from": 10, "to": 100 }
-            ]
+            "$ref": "midi-message-byte-range.schema.json"
         },
         "def_midivelocity_layer": {
             "type": "object",

--- a/midisampling/appconfig/json.schema.files/midi/midi-message-byte-range.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-message-byte-range.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Represents the value range (0-127) of the MIDI message byte",
+    "properties": {
+        "from": {
+            "$ref": "midi-message-byte.schema.json"
+        },
+        "to": {
+            "$ref": "midi-message-byte.schema.json"
+        }
+    },
+    "required": [
+        "from",
+        "to"
+    ],
+    "examples": [
+        { "from": 10, "to": 100 }
+    ]
+}

--- a/midisampling/appconfig/json.schema.files/midi/midi-message-byte.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-message-byte.schema.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "integer",
+    "description": "Represents the value of the MIDI message byte (0-127)",
+    "minimum": 0,
+    "maximum": 127
+}

--- a/midisampling/appconfig/json.schema.files/midi/midi-program-change.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-program-change.schema.json
@@ -4,22 +4,16 @@
     "additionalProperties": false,
     "properties": {
         "msb": {
-            "type": "integer",
-            "description": "MSB value for the MIDI program change.",
-            "minimum": 0,
-            "maximum": 127
+            "$ref": "midi-message-byte.schema.json",
+            "description": "MSB value for the MIDI program change."
         },
         "lsb": {
-            "type": "integer",
-            "description": "LSB value for the MIDI program change.",
-            "minimum": 0,
-            "maximum": 127
+            "$ref": "midi-message-byte.schema.json",
+            "description": "LSB value for the MIDI program change."
         },
         "program": {
-            "type": "integer",
-            "description": "Program number for the MIDI program change.",
-            "minimum": 0,
-            "maximum": 127
+            "$ref": "midi-message-byte.schema.json",
+            "description": "Program number for the MIDI program change."
         }
     },
     "required": [

--- a/midisampling/appconfig/json.schema.files/midi/midi-program-change.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-program-change.schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "msb": {
+            "type": "integer",
+            "description": "MSB value for the MIDI program change.",
+            "minimum": 0,
+            "maximum": 127
+        },
+        "lsb": {
+            "type": "integer",
+            "description": "LSB value for the MIDI program change.",
+            "minimum": 0,
+            "maximum": 127
+        },
+        "program": {
+            "type": "integer",
+            "description": "Program number for the MIDI program change.",
+            "minimum": 0,
+            "maximum": 127
+        }
+    },
+    "required": [
+        "msb",
+        "lsb",
+        "program"
+    ],
+    "examples": [
+        {
+            "msb": 1,
+            "lsb": 23,
+            "program": 45
+        }
+    ]
+}

--- a/midisampling/appconfig/json.schema.files/midi/midi-velocity-layer-preset.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-velocity-layer-preset.schema.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Velocity layers preset configuration.",
+    "properties": {
+        "id": {
+            "type": "integer",
+            "description": "ID of the velocity layer preset."
+        },
+        "velocities": {
+            "type": "array",
+            "items": [
+                {
+                    "$ref": "midi-velocity-layer.schema.json"
+                }
+            ]
+        }
+    },
+    "required": [
+        "id",
+        "velocities"
+    ],
+    "examples": [
+        {
+            "id": 0,
+            "velocities": [
+                { "min": 0,  "max": 31,  "send": 31 },
+                { "min": 32, "max": 63,  "send": 63 },
+                { "min": 64, "max": 95,  "send": 95 },
+                { "min": 96, "max": 127, "send": 127 }
+            ]
+        }
+    ]
+}

--- a/midisampling/appconfig/json.schema.files/midi/midi-velocity-layer.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-velocity-layer.schema.json
@@ -5,22 +5,16 @@
     "description": "Velocity layer configuration",
     "properties": {
         "min": {
-            "type": "integer",
-            "description": "Minimum velocity value.",
-            "minimum": 0,
-            "maximum": 127
+            "$ref": "midi-message-byte.schema.json",
+            "description": "Minimum velocity value."
         },
         "max": {
-            "type": "integer",
-            "description": "Maximum velocity value.",
-            "minimum": 0,
-            "maximum": 127
+            "$ref": "midi-message-byte.schema.json",
+            "description": "Maximum velocity value."
         },
         "send": {
-            "type": "integer",
-            "description": "Velocity value actually sent to the MIDI device when sampling.",
-            "minimum": 0,
-            "maximum": 127
+            "$ref": "midi-message-byte.schema.json",
+            "description": "Velocity value actually sent to the MIDI device when sampling."
         }
     },
     "required": [

--- a/midisampling/appconfig/json.schema.files/midi/midi-velocity-layer.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-velocity-layer.schema.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Velocity layer configuration",
+    "properties": {
+        "min": {
+            "type": "integer",
+            "description": "Minimum velocity value.",
+            "minimum": 0,
+            "maximum": 127
+        },
+        "max": {
+            "type": "integer",
+            "description": "Maximum velocity value.",
+            "minimum": 0,
+            "maximum": 127
+        },
+        "send": {
+            "type": "integer",
+            "description": "Velocity value actually sent to the MIDI device when sampling.",
+            "minimum": 0,
+            "maximum": 127
+        }
+    },
+    "required": [
+        "min",
+        "max",
+        "send"
+    ],
+    "examples": [
+        {
+            "min": 0,
+            "max": 127,
+            "send": 127
+        }
+    ]
+}

--- a/midisampling/appconfig/json.schema.files/midi/sample-zone-complex.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/sample-zone-complex.schema.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "Sample zone complex configuration. The key range, root key, must be specified explicitly.",
+    "properties": {
+        "key_low": {
+            "type": "integer",
+            "description": "Lowest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
+            "minimum": 0,
+            "maximum": 127
+        },
+        "key_high": {
+            "type": "integer",
+            "description": "Highest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
+            "minimum": 0,
+            "maximum": 127
+        },
+        "key_root": {
+            "type": "integer",
+            "description": "Root key number (note number) in the keymap. This value is intended to be used as information for mapping note-on messages sent to MIDI devices and third-party sampler software when sampling.",
+            "minimum": 0,
+            "maximum": 127
+        },
+        "velocity_layers": {
+            "type": "array",
+            "items": [
+                {
+                    "$ref": "midi-velocity-layer.schema.json"
+                }
+            ]
+        },
+        "velocity_layers_preset_id": {
+            "type": "integer",
+            "description": "ID of the velocity layer preset."
+        }
+    },
+    "required": [
+        "key_low",
+        "key_high",
+        "key_root"
+    ],
+    "examples": [
+        {
+            "key_low": 0,
+            "key_high": 32,
+            "key_root": 16,
+            "velocity_layers": [
+                { "min": 0,  "max": 31,  "send": 31 },
+                { "min": 32, "max": 63,  "send": 63 },
+                { "min": 64, "max": 95,  "send": 95 },
+                { "min": 96, "max": 127, "send": 127 }
+            ]
+        },
+        {
+            "key_low": 0,
+            "key_high": 32,
+            "key_root": 16,
+            "velocity_layers_preset_id": 0
+        }
+    ]
+}

--- a/midisampling/appconfig/json.schema.files/midi/sample-zone.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/sample-zone.schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "description": "A simple configuration of sample zone. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`.",
+    "properties": {
+        "keys": {
+            "description": "Root key number (note number) in the keymap.",
+            "$ref": "midi-message-byte-range.schema.json"
+        },
+        "velocity_layers": {
+            "type": "array",
+            "items": [
+                {
+                    "$ref": "midi-velocity-layer.schema.json"
+                }
+            ]
+        },
+        "velocity_layers_preset_id": {
+            "type": "integer",
+            "description": "ID of the velocity layer preset."
+        }
+    },
+    "required": [
+        "keys"
+    ],
+    "examples": [
+        {
+            "keys": { "from": 10, "to": 100 },
+            "velocity_layers": [
+                { "min": 0,  "max": 31,  "send": 31 },
+                { "min": 32, "max": 63,  "send": 63 },
+                { "min": 64, "max": 95,  "send": 95 },
+                { "min": 96, "max": 127, "send": 127 }
+            ]
+        },
+        {
+            "keys": { "from": 10, "to": 100 },
+            "velocity_layers_preset_id": 0
+        }
+    ]
+}

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -23,6 +23,7 @@ validator: JsonValidator = JsonValidator(
         ("integer-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "integer-range.schema.json")),
         ("midi-message-byte.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte.schema.json")),
         ("midi-message-byte-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte-range.schema.json")),
+        ("midi-velocity-layer.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer.schema.json")),
     ])
 )
 

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -26,6 +26,7 @@ validator: JsonValidator = JsonValidator(
         ("midi-velocity-layer.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer.schema.json")),
         ("midi-velocity-layer-preset.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer-preset.schema.json")),
         ("sample-zone-complex.schema.json", os.path.join(SCHEMA_FILES_DIR, "sample-zone-complex.schema.json")),
+        ("sample-zone.schema.json", os.path.join(SCHEMA_FILES_DIR, "sample-zone.schema.json")),
     ])
 )
 

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -8,6 +8,9 @@ from midisampling.jsonvalidation.validator import JsonSchemaInfo, JsonValidator
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 SCHEMA_FILES_DIR = os.path.join(THIS_SCRIPT_DIR, "json.schema.files", "midi")
 
+def __schema_path(schema_file_name: str) -> str:
+    return os.path.join(SCHEMA_FILES_DIR, schema_file_name)
+
 #-----------------------------------------
 # JSON Validator setup with schema files
 #-----------------------------------------
@@ -15,19 +18,19 @@ validator: JsonValidator = JsonValidator(
     # Main Schema
     JsonSchemaInfo.from_file(
         schema_uri="main",
-        schema_file_path=os.path.join(SCHEMA_FILES_DIR, "midi-config.schema.json")
+        schema_file_path=__schema_path("midi-config.schema.json")
     ),
     # Sub Schema
     JsonSchemaInfo.from_files([
-        ("midi-channel.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-channel.schema.json")),
-        ("integer-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "integer-range.schema.json")),
-        ("midi-message-byte.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte.schema.json")),
-        ("midi-message-byte-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte-range.schema.json")),
-        ("midi-velocity-layer.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer.schema.json")),
-        ("midi-velocity-layer-preset.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer-preset.schema.json")),
-        ("midi-program-change.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-program-change.schema.json")),
-        ("sample-zone-complex.schema.json", os.path.join(SCHEMA_FILES_DIR, "sample-zone-complex.schema.json")),
-        ("sample-zone.schema.json", os.path.join(SCHEMA_FILES_DIR, "sample-zone.schema.json")),
+        ("midi-channel.schema.json", __schema_path("midi-channel.schema.json")),
+        ("integer-range.schema.json", __schema_path("integer-range.schema.json")),
+        ("midi-message-byte.schema.json", __schema_path("midi-message-byte.schema.json")),
+        ("midi-message-byte-range.schema.json", __schema_path("midi-message-byte-range.schema.json")),
+        ("midi-velocity-layer.schema.json", __schema_path("midi-velocity-layer.schema.json")),
+        ("midi-velocity-layer-preset.schema.json", __schema_path("midi-velocity-layer-preset.schema.json")),
+        ("midi-program-change.schema.json", __schema_path("midi-program-change.schema.json")),
+        ("sample-zone-complex.schema.json", __schema_path("sample-zone-complex.schema.json")),
+        ("sample-zone.schema.json", __schema_path("sample-zone.schema.json")),
     ])
 )
 

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -19,7 +19,10 @@ validator: JsonValidator = JsonValidator(
     ),
     # Sub Schema
     JsonSchemaInfo.from_files([
-        ("midi-channel.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-channel.schema.json"))
+        ("midi-channel.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-channel.schema.json")),
+        ("integer-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "integer-range.schema.json")),
+        ("midi-message-byte.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte.schema.json")),
+        ("midi-message-byte-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte-range.schema.json")),
     ])
 )
 

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -3,10 +3,26 @@ import os
 import json
 import jsonschema
 
-THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+from midisampling.jsonvalidation.validator import JsonSchemaInfo, JsonValidator
 
-with open(os.path.join(THIS_SCRIPT_DIR, "midi-config.schema.json"), "r") as f:
-    json_schema = json.load(f)
+THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SCHEMA_FILES_DIR = os.path.join(THIS_SCRIPT_DIR, "json.schema.files", "midi")
+
+#-----------------------------------------
+# JSON Validator setup with schema files
+#-----------------------------------------
+validator: JsonValidator = JsonValidator(
+    # Main Schema
+    JsonSchemaInfo.from_file(
+        schema_uri="main",
+        schema_file_path=os.path.join(SCHEMA_FILES_DIR, "midi-config.schema.json")
+    ),
+    # Sub Schema
+    JsonSchemaInfo.from_files([
+        ("midi-channel.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-channel.schema.json"))
+    ])
+)
+
 
 def _to_abs_filepath(base_dir: str, file_path: str) -> str:
     """
@@ -337,7 +353,7 @@ class MidiConfig:
 def validate(config_path: str) -> dict:
     with open(config_path, "r") as f:
         config_json = json.load(f)
-        jsonschema.validate(config_json, json_schema)
+        validator.validate(config_json)
     return config_json
 
 def load(config_path: str) -> MidiConfig:

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -25,6 +25,7 @@ validator: JsonValidator = JsonValidator(
         ("midi-message-byte-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte-range.schema.json")),
         ("midi-velocity-layer.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer.schema.json")),
         ("midi-velocity-layer-preset.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer-preset.schema.json")),
+        ("sample-zone-complex.schema.json", os.path.join(SCHEMA_FILES_DIR, "sample-zone-complex.schema.json")),
     ])
 )
 

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -25,6 +25,7 @@ validator: JsonValidator = JsonValidator(
         ("midi-message-byte-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte-range.schema.json")),
         ("midi-velocity-layer.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer.schema.json")),
         ("midi-velocity-layer-preset.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer-preset.schema.json")),
+        ("midi-program-change.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-program-change.schema.json")),
         ("sample-zone-complex.schema.json", os.path.join(SCHEMA_FILES_DIR, "sample-zone-complex.schema.json")),
         ("sample-zone.schema.json", os.path.join(SCHEMA_FILES_DIR, "sample-zone.schema.json")),
     ])

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -24,6 +24,7 @@ validator: JsonValidator = JsonValidator(
         ("midi-message-byte.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte.schema.json")),
         ("midi-message-byte-range.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-message-byte-range.schema.json")),
         ("midi-velocity-layer.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer.schema.json")),
+        ("midi-velocity-layer-preset.schema.json", os.path.join(SCHEMA_FILES_DIR, "midi-velocity-layer-preset.schema.json")),
     ])
 )
 

--- a/midisampling/jsonvalidation/validator.py
+++ b/midisampling/jsonvalidation/validator.py
@@ -3,26 +3,25 @@ import os
 import json
 from logging import getLogger
 from jsonschema import validate as json_validate
-from referencing import Registry
+from referencing import Registry, Resource
 
 logger = getLogger(__name__)
 
 class JsonSchemaInfo:
-    def __init__(self, schema_uri: str, schema_file_path: str):
-        """
-        Initialize the JsonSchemaInfo with a schema URI and a schema file path.
 
-        Parameters
-        ----------
-        schema_uri: str
-            The URI of the schema. This value is used in the "$ref" field of the schema.
-        schema_file_path: str
-            The file path of the schema.
-        """
-        self.schema_uri = schema_uri
-        self.schema_file_path = schema_file_path
+    @classmethod
+    def from_content(cls, schema_uri: str, schema_content: any):
+        return cls(schema_uri, schema_content)
+
+    @classmethod
+    def from_file(cls, schema_uri: str, schema_file_path: str):
         with open(schema_file_path, "r", encoding="utf-8") as f:
-            self.schema = json.load(f)
+            schema = json.load(f)
+        return cls(schema_uri, schema)
+
+    def __init__(self, schema_uri: str, schema: any):
+        self.schema_uri: str = schema_uri
+        self.schema: any = schema
 
 class JsonValidator:
     def __init__(self, main_schema: JsonSchemaInfo, sub_schema_info_list: List[JsonSchemaInfo] = []):
@@ -88,39 +87,18 @@ class JsonValidator:
         """
         self.main_schema = main_schema
         self.sub_schema_info_list = sub_schema_info_list
-        self.registry = Registry().with_resource(main_schema.schema_uri, main_schema.schema)
+        self.registry = Registry().with_resources([
+            (main_schema.schema_uri, Resource.from_contents(main_schema.schema))
+        ])
 
         for x in self.sub_schema_info_list:
-            self.registry = self.registry.with_resource(x.schema_uri, x.schema)
+            self.registry = self.registry.with_resources([
+                (x.schema_uri, Resource.from_contents(x.schema))
+            ])
 
-        print(self.registry.items())
-
-        for uri, _ in self.registry.items():
-            print(f"  - {uri}")
-
-    def validate(self, json_body: dict) -> bool:
+    def validate(self, json_body) -> bool:
         json_validate(
             instance=json_body,
             schema=self.main_schema.schema,
             registry=self.registry
         )
-
-
-if __name__ == "__main__":
-    import sys
-    THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-
-    try:
-        main_schema = JsonSchemaInfo(
-            schema_uri="main",
-            schema_file_path=os.path.join(THIS_DIR, "..", "appconfig", "midi-config.schema.json")
-        )
-
-        with open(sys.argv[1], "r", encoding="utf-8") as f:
-            json_body = json.load(f)
-
-        validator = JsonValidator(main_schema)
-        validator.validate(json_body)
-        print("OK")
-    except Exception as e:
-        print(e)

--- a/midisampling/jsonvalidation/validator.py
+++ b/midisampling/jsonvalidation/validator.py
@@ -52,7 +52,7 @@ class JsonSchemaInfo:
         self.schema: any = schema
 
 class JsonValidator:
-    def __init__(self, main_schema: JsonSchemaInfo, sub_schema_info_list: List[JsonSchemaInfo] = []):
+    def __init__(self, main_schema_info: JsonSchemaInfo, sub_schema_info_list: List[JsonSchemaInfo] = []):
         """
         Initialize the JsonValidator with a list of schema info.
 
@@ -64,59 +64,20 @@ class JsonValidator:
         --------
 
         ```python
-        validator = JsonValidator(
-            sub_schema_info_list = [
-                JsonSchemaInfo("schema/person", "schema/person.json"),
-                JsonSchemaInfo("schema/organization", "schema/organization.json")
-            ]
-        )
-
-        json_body = {
-            "name": "Taro Yamaada",
-            "age": 30,
-            "organization": {
-                "name": "Acme Corporation"
-            }
-        }
-        validator.validate(json_body)
-        ```
-
-        ## JSON schema examples: person.json
-        ```json
-        {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "age": {
-                    "type": "integer"
-                },
-                "organization": {
-                    "$ref": "schema/organization"
-                }
-            }
-        }
-        ```
-
-        ## JSON schema examples: organization.json
-        ```json
-        {
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                }
-            }
-        }
+        >>> validator = JsonValidator(
+        ...     main_schema_info = JsonSchemaInfo("schema/main", "schema/main.json"),
+        ...     sub_schema_info_list = JsonSchemaInfo.from_files([
+        ...         ("schema/person", "schema/person.json"),
+        ...         ("schema/organization", "schema/organization.json")
+        ...     ])
+        ... )
         ```
         """
-        self.main_schema = main_schema
+
+        self.main_schema = main_schema_info
         self.sub_schema_info_list = sub_schema_info_list
         self.registry = Registry().with_resources([
-            (main_schema.schema_uri, Resource.from_contents(main_schema.schema))
+            (main_schema_info.schema_uri, Resource.from_contents(main_schema_info.schema))
         ])
 
         for x in self.sub_schema_info_list:

--- a/midisampling/jsonvalidation/validator.py
+++ b/midisampling/jsonvalidation/validator.py
@@ -10,14 +10,42 @@ logger = getLogger(__name__)
 class JsonSchemaInfo:
 
     @classmethod
-    def from_content(cls, schema_uri: str, schema_content: any):
+    def from_content(cls, schema_uri: str, schema_content: any) -> "JsonSchemaInfo":
         return cls(schema_uri, schema_content)
 
     @classmethod
-    def from_file(cls, schema_uri: str, schema_file_path: str):
+    def from_file(cls, schema_uri: str, schema_file_path: str) -> "JsonSchemaInfo":
         with open(schema_file_path, "r", encoding="utf-8") as f:
             schema = json.load(f)
         return cls(schema_uri, schema)
+
+    @classmethod
+    def from_files(cls, schema_info_list: List[Tuple[str, str]]) -> List["JsonSchemaInfo"]:
+        """
+        Create a list of JsonSchemaInfo from a list of schema file paths.
+
+        Parameters
+        ----------
+        schema_info_list: List[Tuple[str, str]]
+            A list of pairs of schema URI and schema file path.
+            e.g.
+            ```python
+            [
+                ("schema/person", "schema/person.json"),
+                ("schema/organization", "schema/organization.json")
+            ]
+            ```
+
+        Returns
+        -------
+        List[JsonSchemaInfo]
+            A list of JsonSchemaInfo.
+        """
+        result: List[JsonSchemaInfo] = []
+        for schema_uri, schema_file_path in schema_info_list:
+            result.append(cls.from_file(schema_uri, schema_file_path))
+
+        return result
 
     def __init__(self, schema_uri: str, schema: any):
         self.schema_uri: str = schema_uri

--- a/midisampling/jsonvalidation/validator.py
+++ b/midisampling/jsonvalidation/validator.py
@@ -1,0 +1,126 @@
+from typing import List, Dict, Tuple
+import os
+import json
+from logging import getLogger
+from jsonschema import validate as json_validate
+from referencing import Registry
+
+logger = getLogger(__name__)
+
+class JsonSchemaInfo:
+    def __init__(self, schema_uri: str, schema_file_path: str):
+        """
+        Initialize the JsonSchemaInfo with a schema URI and a schema file path.
+
+        Parameters
+        ----------
+        schema_uri: str
+            The URI of the schema. This value is used in the "$ref" field of the schema.
+        schema_file_path: str
+            The file path of the schema.
+        """
+        self.schema_uri = schema_uri
+        self.schema_file_path = schema_file_path
+        with open(schema_file_path, "r", encoding="utf-8") as f:
+            self.schema = json.load(f)
+
+class JsonValidator:
+    def __init__(self, main_schema: JsonSchemaInfo, sub_schema_info_list: List[JsonSchemaInfo] = []):
+        """
+        Initialize the JsonValidator with a list of schema info.
+
+        Parameters
+        ----------
+        sub_schema_info_list: List[JsonSchemaInfo]
+            A list of JsonSchemaInfo.
+        Examples
+        --------
+
+        ```python
+        validator = JsonValidator(
+            sub_schema_info_list = [
+                JsonSchemaInfo("schema/person", "schema/person.json"),
+                JsonSchemaInfo("schema/organization", "schema/organization.json")
+            ]
+        )
+
+        json_body = {
+            "name": "Taro Yamaada",
+            "age": 30,
+            "organization": {
+                "name": "Acme Corporation"
+            }
+        }
+        validator.validate(json_body)
+        ```
+
+        ## JSON schema examples: person.json
+        ```json
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                },
+                "organization": {
+                    "$ref": "schema/organization"
+                }
+            }
+        }
+        ```
+
+        ## JSON schema examples: organization.json
+        ```json
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        }
+        ```
+        """
+        self.main_schema = main_schema
+        self.sub_schema_info_list = sub_schema_info_list
+        self.registry = Registry().with_resource(main_schema.schema_uri, main_schema.schema)
+
+        for x in self.sub_schema_info_list:
+            self.registry = self.registry.with_resource(x.schema_uri, x.schema)
+
+        print(self.registry.items())
+
+        for uri, _ in self.registry.items():
+            print(f"  - {uri}")
+
+    def validate(self, json_body: dict) -> bool:
+        json_validate(
+            instance=json_body,
+            schema=self.main_schema.schema,
+            registry=self.registry
+        )
+
+
+if __name__ == "__main__":
+    import sys
+    THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+    try:
+        main_schema = JsonSchemaInfo(
+            schema_uri="main",
+            schema_file_path=os.path.join(THIS_DIR, "..", "appconfig", "midi-config.schema.json")
+        )
+
+        with open(sys.argv[1], "r", encoding="utf-8") as f:
+            json_body = json.load(f)
+
+        validator = JsonValidator(main_schema)
+        validator.validate(json_body)
+        print("OK")
+    except Exception as e:
+        print(e)


### PR DESCRIPTION
Bloated schema files were divided by structure and made reusable.

Implemented `$ref` references to refs using [referncing](https://pypi.org/project/referencing/) instead of resolver, which was [deprecated](https://python-jsonschema.readthedocs.io/en/stable/api/jsonschema/protocols/) in [jsonschema](https://pypi.org/project/jsonschema/).