### PR TITLE
Feature/velocity layer file from sample

### DIFF
--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -47,6 +47,12 @@
             "velocity_layers_preset_id": 0
         },
         {
+            "key_low": 32,
+            "key_high": 64,
+            "key_root": 48,
+            "velocity_layers_file": "velocity_layers_example.json"
+        },
+        {
             "file": "sample_zone_complex_example.json"
         }
     ],
@@ -71,6 +77,10 @@
                     }
                 }
             ]
+        },
+        {
+            "keys": {"from": 50, "to": 50},
+            "velocity_layers_file": "velocity_layers_example.json"
         },
         {
             "file": "sample_zone_example.json"

--- a/midisampling/appconfig/json.schema.files/midi/sample-zone-complex.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/sample-zone-complex.schema.json
@@ -4,6 +4,7 @@
     "description": "Sample zone complex configuration. The key range, root key, must be specified explicitly.",
     "oneOf": [
         {
+            "description": "Define with individual parameters",
             "additionalProperties": false,
             "properties": {
                 "key_low": {
@@ -51,6 +52,7 @@
             ]
         },
         {
+            "description": "Define with velocity layers preset ID",
             "additionalProperties": false,
             "properties": {
                 "key_low": {
@@ -87,6 +89,46 @@
                     "velocity_layers_preset_id": 0
                 }
             ]
+        },
+        {
+            "description": "Define with velocity layers file",
+            "additionalProperties": false,
+            "properties": {
+                "key_low": {
+                    "description": "Lowest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
+                    "$ref": "midi-notenumber.schema.json"
+                },
+                "key_high": {
+                    "description": "Highest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
+                    "$ref": "midi-notenumber.schema.json"
+                },
+                "key_root": {
+                    "description": "Root key number (note number) in the keymap. This value is intended to be used as information for mapping note-on messages sent to MIDI devices and third-party sampler software when sampling.",
+                    "$ref": "midi-notenumber.schema.json"
+                },
+                "velocity_layers_file": {
+                    "type": "string",
+                    "description": "File path of the velocity layers definition file."
+                },
+                "note_duration": {
+                    "$ref": "midi-note-duration.schema.json"
+                }
+            },
+            "required": [
+                "key_low",
+                "key_high",
+                "key_root",
+                "velocity_layers_file"
+            ],
+            "examples": [
+                {
+                    "key_low": 0,
+                    "key_high": 32,
+                    "key_root": 16,
+                    "velocity_layers_file": "velocity_layers.json"
+                }
+            ]
         }
+
     ]
 }

--- a/midisampling/appconfig/json.schema.files/midi/sample-zone.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/sample-zone.schema.json
@@ -4,6 +4,7 @@
     "description": "A simple configuration of sample zone. Unlike the complex version, only the root key can be specified, and individual values of `key_range` are applied as `root key`, `low key` and `high key`.",
     "oneOf": [
         {
+            "description": "Define with individual parameters",
             "additionalProperties": false,
             "properties": {
                 "keys": {
@@ -52,6 +53,7 @@
             ]
         },
         {
+            "description": "Define with velocity layers preset ID",
             "additionalProperties": false,
             "properties": {
                 "keys": {
@@ -78,6 +80,46 @@
                 {
                     "keys": { "from": 10, "to": 100 },
                     "velocity_layers_preset_id": 0,
+                    "note_durations": [
+                        {
+                            "notes": [40, 41, 42],
+                            "duration": {
+                                "note_time": 10,
+                                "release_time": 2.0
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "Define with velocity layers file",
+            "additionalProperties": false,
+            "properties": {
+                "keys": {
+                    "description": "Root key number (note number) in the keymap.",
+                    "$ref": "midi-notenumber-range.schema.json"
+                },
+                "velocity_layers_file": {
+                    "type": "string",
+                    "description": "File path of the velocity layers definition file."
+                },
+                "note_durations": {
+                    "description": "The list of MIDI notes and their duration.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "sample-zone-note-duration.schema.json"
+                    }
+                }
+            },
+            "required": [
+                "keys",
+                "velocity_layers_file"
+            ],
+            "examples": [
+                {
+                    "keys": { "from": 10, "to": 100 },
+                    "velocity_layers_file": "velocity_layers.json",
                     "note_durations": [
                         {
                             "notes": [40, 41, 42],

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -366,7 +366,15 @@ class SampleZone:
             key_low  = zone["key_low"]
             key_high = zone["key_high"]
 
-            velocity_layers: List[VelocityLayer] = SampleZone.__parse_velocity_layer(zone, velocity_layers_presets)
+            velocity_layers: List[VelocityLayer] = []
+
+            if "velocity_layers_file" in zone:
+                file_path = _to_abs_filepath(config_dir, zone["velocity_layers_file"])
+                base_dir = os.path.dirname(file_path)
+                velocity_layers = VelocityLayer.parse_velocity_layers_file(file_path)
+            else:
+                velocity_layers = SampleZone.__parse_velocity_layer(zone, velocity_layers_presets)
+
 
             if len(velocity_layers) == 0:
                 raise ValueError(f"velocity layers is empty.")
@@ -417,7 +425,6 @@ class SampleZone:
                 file_path = _to_abs_filepath(config_dir, zone["velocity_layers_file"])
                 base_dir = os.path.dirname(file_path)
                 velocity_layers = VelocityLayer.parse_velocity_layers_file(file_path)
-                print(f"velocity_layers={[str(x) for x in velocity_layers]}")
             else:
                 velocity_layers = SampleZone.__parse_velocity_layer(zone, velocity_layers_presets)
 


### PR DESCRIPTION
Import velocity layers directry from file in Sample Zone has supported
サンプルゾーンのベロシティレイヤーをファイルから直接インポートできるようにした。

The velocity layer preset will be removed in the future.
将来 velocity layer preset は削除する予定
