### PR TITLE
Comment text supported in velocity-layer and sample-zone files

### DIFF
--- a/examples/midi-config.example.json
+++ b/examples/midi-config.example.json
@@ -12,6 +12,11 @@
     ],
     "sample_zone_complex": [
         {
+            "$comment": "Sample zone complex configuration",
+            "$comments": [
+                "Sample zone complex configuration",
+                "Sample zone complex configuration"
+            ],
             "key_low": 0,
             "key_high": 32,
             "key_root": 16,
@@ -37,6 +42,11 @@
     ],
     "sample_zone": [
         {
+            "$comment": "Sample zone configuration",
+            "$comments": [
+                "Sample zone configuration",
+                "Sample zone configuration"
+            ],
             "keys": {"from": 40, "to": 40},
             "velocity_layers": [
                 {"min": 0,  "max": 31,  "send": 31},

--- a/midisampling/appconfig/json.schema.files/midi/comment.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/comment.schema.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "string",
+    "description": "Any text can be written here."
+}

--- a/midisampling/appconfig/json.schema.files/midi/comments.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/comments.schema.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "array",
+    "description": "Any text can be written here.",
+    "items": {
+        "type": "string"
+    }
+}

--- a/midisampling/appconfig/json.schema.files/midi/midi-velocity-layer.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/midi-velocity-layer.schema.json
@@ -4,6 +4,12 @@
     "additionalProperties": false,
     "description": "Velocity layer configuration",
     "properties": {
+        "$comment": {
+            "$ref": "comment.schema.json"
+        },
+        "$comments": {
+            "$ref": "comments.schema.json"
+        },
         "min": {
             "description": "Minimum velocity value.",
             "$ref": "midi-velocity.schema.json"

--- a/midisampling/appconfig/json.schema.files/midi/sample-zone-complex.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/sample-zone-complex.schema.json
@@ -7,6 +7,12 @@
             "description": "Define with individual parameters",
             "additionalProperties": false,
             "properties": {
+                "$comment": {
+                    "$ref": "comment.schema.json"
+                },
+                "$comments": {
+                    "$ref": "comments.schema.json"
+                },
                 "key_low": {
                     "description": "Lowest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
                     "$ref": "midi-notenumber.schema.json"
@@ -55,6 +61,12 @@
             "description": "Define with velocity layers file",
             "additionalProperties": false,
             "properties": {
+                "$comment": {
+                    "$ref": "comment.schema.json"
+                },
+                "$comments": {
+                    "$ref": "comments.schema.json"
+                },
                 "key_low": {
                     "description": "Lowest key number (note number) in the keymap. This value is intended to be used as information for mapping with third-party sampler software.",
                     "$ref": "midi-notenumber.schema.json"

--- a/midisampling/appconfig/json.schema.files/midi/sample-zone.schema.json
+++ b/midisampling/appconfig/json.schema.files/midi/sample-zone.schema.json
@@ -7,6 +7,12 @@
             "description": "Define with individual parameters",
             "additionalProperties": false,
             "properties": {
+                "$comment": {
+                    "$ref": "comment.schema.json"
+                },
+                "$comments": {
+                    "$ref": "comments.schema.json"
+                },
                 "keys": {
                     "description": "Root key number (note number) in the keymap.",
                     "$ref": "midi-notenumber-range.schema.json"
@@ -56,6 +62,12 @@
             "description": "Define with velocity layers file",
             "additionalProperties": false,
             "properties": {
+                "$comment": {
+                    "$ref": "comment.schema.json"
+                },
+                "$comments": {
+                    "$ref": "comments.schema.json"
+                },
                 "keys": {
                     "description": "Root key number (note number) in the keymap.",
                     "$ref": "midi-notenumber-range.schema.json"

--- a/midisampling/appconfig/midi.py
+++ b/midisampling/appconfig/midi.py
@@ -22,6 +22,8 @@ def _load_json_with_validate(file_path: str, validator: JsonValidator) -> dict:
 
 # Sub Schema list
 sub_schemas: List[JsonSchemaInfo] = JsonSchemaInfo.from_files([
+        ("comment.schema.json", _schema_path("comment.schema.json")),
+        ("comments.schema.json", _schema_path("comments.schema.json")),
         ("midi-channel.schema.json", _schema_path("midi-channel.schema.json")),
         ("integer-range.schema.json", _schema_path("integer-range.schema.json")),
         ("midi-message-byte.schema.json", _schema_path("midi-message-byte.schema.json")),


### PR DESCRIPTION
Support for leaving arbitrary text as `$comment` and `$comments` in velocity layer and sample zone definition files.

ベロシティーレイヤー、サンプルゾーン定義ファイルに `$comment`, `$comments` として任意のテキストを残せるように対応