### PR TITLE
Refactor export implementation to support shared output structure for…

### DIFF
--- a/.agents/contexts/progress/progress.md
+++ b/.agents/contexts/progress/progress.md
@@ -110,6 +110,28 @@ FX 要素を削除したビルドが `ERROR parsing input file at line 31: <synt
 - **最終構成で実機の再読み込み・サスティンループ動作を人間が確認済み(2026-07-30)**。IntModulators のインデックス付き子要素の可変個数は許容されることが確定
 - テストは 310 件全緑
 
+## export 出力レイアウトの共有化(2026-07-31)
+プランは `.agents/plans/2026-0731-shared-export-layout.md`。仕様 `export_implementation.md` §7.1 を新設。
+
+- 出力をパッチ単位(`<root>/<format>/<name>/`)からフォーマット単位の共有ツリーへ変更(ユーザー要望: サンプラーソフト上でファイルを探しやすくするため)
+  ```
+  <root>/<format>/
+  ├── Samples/<tone-id>/*.wav|.flac
+  └── Instruments/<name>.<ext>
+  ```
+  これは KONTAKT ライブラリの慣習(`Instruments/` + `Samples/` がライブラリルート直下)とも一致する
+- **旧レイアウトは残さない**(ユーザー決定。CLI オプションでの切替も不要)
+- **2種類の相対パスを分離**したのが実装の核。以前は 1 本の文字列を両方に使い回していた:
+  - `AudioExportTask.relative_path` = 出力ルート基準 `Samples/<tone-id>/...`(変更なし)
+  - `InstrumentRegion.sample_path` = **パッチファイル基準** `../Samples/<tone-id>/...`
+  - `sample_path` の契約(「パッチファイルからの相対」)は元から docstring に書かれていたため、契約は不変で値だけが変わった
+- `PatchWriteContext.output_directory` → `patch_directory`(= `<format>/Instruments/`)。writer は「パッチを `patch_directory` に書く」「`sample_path` はパッチからの相対」だけを知ればよく、`Instruments`/`Samples` というレイアウト名は writer に漏れない。NKI の WAV 読み戻しも `patch_directory / sample_path` で解決
+- **export に限り既存出力を許容**(ユーザー決定)。`ExportExistingOutputError` を削除。sampling / postprocess の既存出力チェックは無変更
+  - 上書き警告は `Samples/<tone-id>/` **ディレクトリにつき 1 回**。当初サンプル1件ごとに出す実装にしたが、90サンプルの再エクスポートで警告が90行出て実用に耐えないため集約した
+  - 削除・クリーンアップはしないため、定義から外した音色のサンプルは残留する(既知の挙動として仕様に明記)
+- 実機データ(90サンプル)で sfz / nki 両方をエクスポートし、レイアウト・`sample=../Samples/...`・NKI XML の `..\Samples\...`・再実行時の上書きを確認。テストは 317 件全緑
+- **`..` 相対パスの解決を実機で確認済み(ユーザー、2026-07-31)**。sfz / nki とも `Instruments/` 配下のパッチから 1 階層上の `Samples/` を正しく参照できる。KONTAKT・Sforzando ともに `..` を含む相対サンプルパスを扱えることが確定した
+
 ## 補足
 - `examples/sessions/postprocess.yaml` にポストプロセス定義サンプル
 - DSP結合テスト(tests/test_postprocess_stages_integration.py)は `pytest.importorskip` でガード。librosa 解析のため約70秒かかる

--- a/.agents/plans/2026-0731-shared-export-layout.md
+++ b/.agents/plans/2026-0731-shared-export-layout.md
@@ -1,0 +1,91 @@
+# エクスポート出力レイアウトの共有化（Samples / Instruments）
+
+- 関連仕様: `.agents/specs/export_implementation.md` §7.1、`.agents/specs/kontakt1_nki_export.md`
+- 実行結果の記録: `.agents/contexts/progress/progress.md`「export 出力レイアウトの共有化(2026-07-31)」
+
+## 全体のゴール
+
+エクスポート成果物を「パッチ単位の自己完結ディレクトリ」から「フォーマット単位の共有ツリー」へ変更する。
+
+変更前:
+
+```
+path/to/export/${format}/${name}/
+├── ${name}.${ext}
+└── Samples/${tone-id}/*.wav|.flac
+```
+
+変更後:
+
+```
+path/to/export/${format}/
+├── Samples/
+│   ├── ${tone-id1}/*.wav|.flac
+│   └── ${tone-id2}/*.wav|.flac
+└── Instruments/
+    ├── ${name1}.${ext}
+    └── ${name2}.${ext}
+```
+
+**背景**: インストゥルメントが増えるほどサンプルとパッチが分散し、実際のサンプラーソフト（KONTAKT / sforzando）上でファイルを探しにくい。1 箇所にまとめる。これは KONTAKT ライブラリの慣習的レイアウト（`Instruments/` + `Samples/` がライブラリルート直下）とも一致する。
+
+**既存仕様とのバッティング**: 複数インストゥルメントが同じフォーマットルートへ追記していく運用が前提になるため、**export に限り**「出力先が空でなければエラー」の既存ルールを撤廃する。サンプリング・ポストプロセスの既存出力チェックはそのまま維持する。
+
+### 確定済みの方針（ユーザー判断）
+
+- 新レイアウトは無条件に置き換える（旧レイアウトは残さない／CLI オプションも追加しない）
+- `Samples/${tone-id}/` はインストゥルメント間で共有する。既存サンプルを上書きする際は警告ログを出したうえで処理を継続する
+
+## 設計方針
+
+### 1. 2 種類の相対パスを分離する
+
+変更前は 1 本の文字列を `AudioExportTask.relative_path` と `InstrumentRegion.sample_path` の両方に使い回していた。新レイアウトでは基準が異なるため分離する。
+
+| 用途 | 基準 | 値 |
+|---|---|---|
+| `AudioExportTask.relative_path` | フォーマットルート | `Samples/${tone-id}/${stem}${suffix}`（変更なし） |
+| `InstrumentRegion.sample_path` | **パッチファイル** | `../Samples/${tone-id}/${stem}${suffix}` |
+
+`sample_path` の契約は `instrument_model.py` に元から「パッチファイルからの相対 POSIX パス」と書かれているため、**契約は不変で値だけが変わる**。SFZ の `sample=` は POSIX 区切りのまま、NKI は `nki_xml.py` の `replace("/", "\\")` により `..\Samples\...` になる。
+
+### 2. Writer へ渡すのはパッチ配置先ディレクトリ
+
+`PatchWriteContext.output_directory` を `patch_directory`（＝ `<root>/Instruments`）へ置き換える。「パッチは `patch_directory` に書く」「`sample_path` はパッチからの相対」という 1 つの一貫した契約になり、writer 側にレイアウト知識（`Instruments` という名前）が漏れない。NKI writer のエクスポート済み WAV 読み戻しも `patch_directory / region.sample_path` で解決する（`..` は pathlib がそのまま扱える）。
+
+## タスクリスト
+
+### 実装
+
+- [x] `export/planning/export_plan.py`: `INSTRUMENTS_DIRECTORY_NAME` と `PATCH_TO_ROOT_PREFIX` を追加。`AudioExportTask.relative_path` の docstring を「出力ルート基準」と明記。`planning/__init__.py` へ re-export
+- [x] `export/planning/export_plan_builder.py`: `_relative_sample_path` を `_sample_output_path`（ルート基準）と `_sample_reference_path`（パッチ基準）に分離
+- [x] `export/abstractions/instrument_patch_writer.py`: `PatchWriteContext.output_directory` → `patch_directory`。`directory_name` の docstring を新レイアウトへ
+- [x] `export/sfz_impl/sfz_patch_writer.py` / `export/nki_impl/nki_patch_writer.py`: `context.patch_directory` を使用
+- [x] `export/export_executor.py`: 引数を `output_root` へ改名、既存出力チェックを削除、`Instruments/` を作成、`Samples/<tone-id>/` 単位の上書き警告を追加
+- [x] `export/exceptions.py`: `ExportExistingOutputError` を削除
+- [x] `cli.py`: 出力先を `output_root / writer.directory_name` へ。`--output` ヘルプとコマンド docstring を更新
+
+### テスト
+
+- [x] `tests/test_export_cli.py`: 全レイアウト期待値を更新。`test_existing_output_is_refused` を撤去し、再エクスポート成功と 2 楽器のフォーマットルート共有を検証するテストへ差し替え
+- [x] `tests/test_export_plan_builder.py`: `sample_path` == `../` + `relative_path` を明示検証するテストを追加
+- [x] `tests/test_export_sfz_writer.py` / `tests/test_export_nki_writer.py`: `patch_directory` へ移行。NKI フィクスチャは `Instruments/` を作ってそこから `../Samples/...` を解決
+- [x] `tests/test_export_executor.py` を新規作成（レイアウト分割・上書き許容・警告の粒度）
+
+### ドキュメント
+
+- [x] `.agents/specs/export_implementation.md`: §2-4（既存出力の扱い）・§4（writer 契約）・§5（サンプル出力先）・§6（`sample=`）・§7 + §7.1 新設（出力レイアウト）
+- [x] `.agents/specs/kontakt1_nki_export.md`: レイアウト図と WAV 読み戻しの記述
+- [x] `.agents/contexts/progress/progress.md`: 実行結果を記録
+- [x] `examples/sessions/instrument.yaml`: 出力先コメントを新レイアウトへ
+- [x] 本プランの永続化
+
+## 懸念点
+
+- ~~**KONTAKT 1 / sforzando が `..` を解決するか**は実機未検証~~ → **解消**。実機で読み込み確認済み（ユーザー、2026-07-31）。`Instruments/` 配下のパッチから `../Samples/...` を正しく参照できる
+- **パス長**: `Instruments/` 階層が増える一方 `<name>/` 階層が減るため、Windows の 260 文字制限に対しては概ね中立。export は元々 `output_path_validator` を使っていないため本改修でも導入しない（スコープ外）
+- **上書き許容の副作用**: 定義から削除された tone のサンプルが `Samples/` に残留する。掃除機能はスコープ外とし、仕様書に既知の挙動として明記した
+
+## 実行時に判明したこと
+
+- 上書き警告を**サンプル 1 件ごと**に出す実装では、90 サンプルの再エクスポートで警告が 90 行出て実用に耐えなかった。衝突の単位は tone-id であるため、`Samples/<tone-id>/` **ディレクトリにつき 1 回**へ集約した（`ExportExecutor._warn_on_occupied_sample_directories`）

--- a/.agents/specs/export_implementation.md
+++ b/.agents/specs/export_implementation.md
@@ -26,7 +26,9 @@
 1. **既存マニフェストには一切書き込まない。** `resolved_definition_sha256` / `source_manifest_sha256` のハッシュ連鎖を壊すため（ディスカッション §3）。エクスポートは recorded/ ・ processed/ に対して完全に read-only。
 2. **ファイル名の逆解析をしない。** マッピングは全て postprocess_manifest の `samples[].mapping` から取得する（サンプリング仕様 §24、ポストプロセス仕様の派生マニフェスト単独復元原則）。
 3. **`sources` が参照できるのは postprocess_manifest のみ。** recorded/ の sample_manifest 直接参照は不可。postprocess を経ていない音色をエクスポートしたい場合は、trim/loop なしの postprocess を一度通す。
-4. 既存のエクスポート成果物は自動で上書き・削除・再開しない（postprocess と同じ原則）。出力ディレクトリが空でない場合はエラー。
+4. **エクスポートのみ既存出力を許容する。** 出力ルートは複数のインストゥルメントで共有する設計（§7.1）のため、既存ディレクトリ・ファイルが存在してもエラーにせず上書きする。sampling / postprocess の「既存出力があればエラー」原則は従来どおり維持する。
+   - 上書きは追記的で、削除・クリーンアップは一切行わない。定義から外した音色のサンプルは `Samples/` に残留する（既知の挙動）。
+   - `Samples/<tone-id>/` が既にファイルを含む場合、そのディレクトリにつき 1 回だけ警告ログを出す（サンプル 1 件ごとではない）。
 
 ## 3. instrument_definition スキーマ (schema_version: 1)
 
@@ -106,13 +108,16 @@ src/midi_sampling/export/
 - 中間表現 `InstrumentModel` は形式非依存。将来の Falcon / KONTAKT 対応は `<format>_impl/` の追加と `create_patch_writer` への分岐追加だけで済む構造とする。
 - `InstrumentPatchWriter` は Protocol ではなく**抽象基底クラス**とする。Python の Protocol は実装側の継承が文法上不要なため、「インターフェースを実装しているか」を継承関係で判別できない。形式の実装は明示的な継承で表明する。
   - 抽象プロパティ `format_id`（CLI `--format` / ファクトリの識別子）と抽象メソッド `write()` を持つ。
-  - プロパティ `directory_name` は出力レイアウト `<出力ルート>/<directory_name>/<パッチ名>/` のフォーマット別サブディレクトリ名を返す。既定実装は `format_id` を返し、慣習的なディレクトリ名が識別子と異なるフォーマットのみオーバーライドする。
+  - プロパティ `directory_name` は出力レイアウト `<出力ルート>/<directory_name>/{Samples,Instruments}/`（§7.1）のフォーマット別サブディレクトリ名を返す。既定実装は `format_id` を返し、慣習的なディレクトリ名が識別子と異なるフォーマットのみオーバーライドする。
+  - `write()` に渡す `PatchWriteContext` はパッチの配置先 `patch_directory`（＝ `<フォーマットルート>/Instruments/`）を持つ。writer は「パッチを `patch_directory` に書く」「`sample_path` はパッチファイルからの相対」の2点だけを知ればよく、`Instruments` / `Samples` というレイアウト名は writer 側に漏れない。
   - プロパティ `supported_audio_formats` は対象サンプラーが読める音声フォーマットのタプル（既定 `None` = 制限なし）。定義ファイルの `audio.format` が非対応の場合、`ExportPlanBuilder` が警告ログを出して先頭のフォーマットへフォールバックする（例: KONTAKT 1 は FLAC 非対応のため `("wav",)` を返し、flac 指定は wav で出力される）。
 - `soundfile` の import は AudioExporter の関数内 lazy import に閉じる。
 
 ## 5. オーディオ出力
 
-定義ファイルの `audio.format` で選択。出力は常にサンプルごとに `Samples/<tone-id>/<元ファイル名>.<ext>` へ書き出す（tone-id サブディレクトリでファイル名衝突を回避）。
+定義ファイルの `audio.format` で選択。出力は常にサンプルごとに `<フォーマットルート>/Samples/<tone-id>/<元ファイル名>.<ext>` へ書き出す（tone-id サブディレクトリでファイル名衝突を回避）。
+
+`Samples/` はフォーマットルート直下の共有ツリーであり、同じ tone-id を参照する複数のインストゥルメントは同じディレクトリを共有する（§7.1）。
 
 ### 5.1 wav（既定）
 
@@ -131,7 +136,7 @@ src/midi_sampling/export/
 
 ## 6. 中間表現 → SFZ マッピング
 
-出力は `<出力ディレクトリ>/<name>.sfz`（UTF-8、LF）。`sample=` は .sfz からの相対パス（`Samples/<tone-id>/...`、POSIX 区切り）。
+出力は `<フォーマットルート>/Instruments/<name>.sfz`（UTF-8、LF）。`sample=` は .sfz からの相対パス（`../Samples/<tone-id>/...`、POSIX 区切り）。パッチは `Instruments/` 配下にあり、`Samples/` はその 1 つ上の階層にあるため `../` が前置される。
 
 | 中間表現 | SFZ opcode |
 |---|---|
@@ -154,11 +159,28 @@ midi-sampling export <instrument.yaml> [--format sfz] [--output <root>]
 ```
 
 - `--format` 省略時は `sfz`。対応形式は `sfz` / `nki`。未知の形式は定義エラー扱い。
-- パッチの出力先は常に `<出力ルート>/<フォーマット別ディレクトリ名>/<name>/`（例: `patches/sfz/sc8850-cello/`）。フォーマット別ディレクトリ名は Writer の `directory_name`（§4）が決める。
 - `--output` は出力ルートを差し替える。省略時のルートは `<instrument.yaml のあるディレクトリ>/patches/`。
-- 出力ディレクトリ（`<name>/` 階層）が存在して空でない場合はエラー（§2-4）。
+- 既存出力があってもエラーにせず上書きする（§2-4）。
 - 終了コードは既存規約: 成功 0 / 実行失敗 1 / 定義・入力エラー 2。
 - 例外は `MidiSamplingError` を CLI が捕捉する既存方式（`export/exceptions.py` は全て `ExportError(MidiSamplingError)` 派生）。
+
+### 7.1 出力レイアウト
+
+フォーマットごとに 1 つのルート（`<出力ルート>/<フォーマット別ディレクトリ名>/`。例: `patches/sfz/`）を持ち、その配下でサンプルとパッチを種類別にまとめる。フォーマット別ディレクトリ名は Writer の `directory_name`（§4）が決める。
+
+```
+<出力ルート>/<フォーマット別ディレクトリ名>/
+├── Samples/
+│   ├── <tone-id1>/*.wav|.flac
+│   └── <tone-id2>/*.wav|.flac
+└── Instruments/
+    ├── <name1>.<ext>
+    └── <name2>.<ext>
+```
+
+- **パッチ単位でディレクトリを分けない。** 同じフォーマットの全インストゥルメントが 1 つの `Instruments/` に並び、`Samples/` を共有する。サンプラーソフト上でファイルを探しやすくするための構造であり、KONTAKT ライブラリの慣習（`Instruments/` + `Samples/` がライブラリルート直下）とも一致する。
+- 同じ tone-id を参照する複数のインストゥルメントは同じサンプル実体を共有する。tone-id が衝突した場合は後勝ちで上書きされ、警告ログが出る（§2-4）。
+- パッチ内のサンプル参照は必ずパッチファイルからの相対パス（`../Samples/<tone-id>/...`）。プランニング時に、出力ルート基準の書き出し先（`AudioExportTask.relative_path`）とパッチ基準の参照パス（`InstrumentRegion.sample_path`）を別々に組み立てる。
 
 ## 8. 将来拡張のための注記
 

--- a/.agents/specs/kontakt1_nki_export.md
+++ b/.agents/specs/kontakt1_nki_export.md
@@ -9,13 +9,17 @@ XML の細部（version 属性、パラメーター順序、改行コード）�
 `examples/kontakt/example_kontakt_v1.nki`（KONTAKT 1 実ファイル）を
 テンプレートとして踏襲する。
 
-出力レイアウトは SFZ と同一:
+出力レイアウトは SFZ と同一（`export_implementation.md` §7.1）:
 
 ```
-patches/nki/<instrument name>/
-├── <instrument name>.nki
+patches/nki/
+├── Instruments/<instrument name>.nki
 └── Samples/<tone_id>/<stem>.wav
 ```
+
+ゾーンの `file` 値は NKI からの相対パス `..\Samples\<tone_id>\<stem>.wav` になる。
+これは NI 純正ライブラリと同じ `Instruments/` + `Samples/` 構成である。
+`..` を含む相対パスが正しく解決されることは実機で確認済み（2026-07-31）。
 
 ## 2. モジュール構成
 
@@ -33,7 +37,7 @@ src/midi_sampling/export/nki_impl/
   `ExportPlanBuilder.build(..., supported_audio_formats=...)` が非対応
   フォーマット（flac）を検出すると警告ログを出して wav へフォールバックする。
 - ヘッダー `0x1C` のサンプルデータ量とゾーンの `sampleEnd` は、
-  executor が先に書き出した `output_directory` 配下の WAV を
+  executor が先に書き出した WAV（`patch_directory / region.sample_path` で解決）を
   `wav_info.read_wav_data_info()` で走査して得る（stdlib のみ、`wave`
   モジュールは float PCM を拒否するため不使用）。
 

--- a/examples/sessions/instrument.yaml
+++ b/examples/sessions/instrument.yaml
@@ -10,13 +10,17 @@
 # - 相対パスはこのファイルの所在ディレクトリが基準
 # - 絶対パス・URL・`~`・環境変数・glob は使用不可
 # - recorded/ / processed/ は読むだけで、決して書き換えない
-# - 出力先は <出力ルート>/<フォーマット名>/<name>/ (既定ルート: このファイルの隣の patches/)。
-#   sfz なら patches/sfz/<name>/ になる。空でない場合はエラーになる
+# - 出力先は <出力ルート>/<フォーマット名>/ (既定ルート: このファイルの隣の patches/)。
+#   sfz なら patches/sfz/ 配下に次の構造で出力される:
+#     patches/sfz/Samples/<音色ID>/*.wav|.flac   ... サンプル(全楽器で共有)
+#     patches/sfz/Instruments/<name>.sfz         ... パッチ本体
+#   同じフォーマットの複数楽器を 1 箇所にまとめるため、既存の出力があっても
+#   エラーにはならず上書きされる (サンプリング・ポストプロセスは従来どおりエラー)
 
 schema_version: 1
 kind: instrument_definition
 
-# パッチ名。出力ファイル名(<name>.sfz)と既定の出力ディレクトリ名に使われる
+# パッチ名。出力ファイル名(Instruments/<name>.sfz)に使われる
 name: sc8850-cello
 
 # エクスポートするオーディオ形式(省略時: wav)

--- a/src/midi_sampling/cli.py
+++ b/src/midi_sampling/cli.py
@@ -71,7 +71,9 @@ OutputDirectoryOption = Annotated[
         "--output",
         "-o",
         help=(
-            "Output root; the patch is written to <output>/<format>/<name>. "
+            "Output root; the patch is written to "
+            "<output>/<format>/Instruments/<name>.<ext> and its samples to "
+            "<output>/<format>/Samples/<tone-id>/. "
             "Defaults to patches/ next to the instrument definition file."
         ),
         show_default=False,
@@ -215,8 +217,10 @@ def export(
     Generate a sampler patch from postprocessed sampling output.
 
     Reads an instrument definition, copies (or encodes) the processed
-    samples into a self-contained output directory and writes the patch
-    file next to them. Never modifies the recorded or processed trees.
+    samples into `<format>/Samples/` and writes the patch into
+    `<format>/Instruments/`, so that every instrument of one format
+    shares a single tree. Never modifies the recorded or processed
+    trees; existing export output is overwritten.
     """
     _init_logging(verbose)
 
@@ -237,7 +241,7 @@ def export(
     output_root = (
         output if output is not None else resolved.definition_path.parent / "patches"
     )
-    output_directory = output_root / writer.directory_name / plan.instrument.name
+    format_root = output_root / writer.directory_name
 
     from midi_sampling.export.audio import AudioExporter
     from midi_sampling.export.export_executor import ExportExecutor
@@ -251,7 +255,7 @@ def export(
     )
 
     try:
-        patch_path = executor.execute(plan, output_directory)
+        patch_path = executor.execute(plan, format_root)
     except MidiSamplingError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(EXIT_EXECUTION_FAILED)

--- a/src/midi_sampling/export/abstractions/instrument_patch_writer.py
+++ b/src/midi_sampling/export/abstractions/instrument_patch_writer.py
@@ -8,12 +8,13 @@ from midi_sampling.export.abstractions.instrument_model import InstrumentModel
 @dataclass(frozen=True)
 class PatchWriteContext:
     """
-    Everything a writer needs to emit one patch file. The audio files
-    referenced by the regions have already been written below
-    `output_directory` when a writer runs.
+    Everything a writer needs to emit one patch file. The patch goes
+    into `patch_directory`; the audio files have already been written
+    when a writer runs and are reachable by joining `patch_directory`
+    with each region's `sample_path`.
     """
     instrument: InstrumentModel
-    output_directory: Path
+    patch_directory: Path
 
 
 @dataclass(frozen=True)
@@ -46,8 +47,8 @@ class InstrumentPatchWriter(metaclass=abc.ABCMeta):
     def directory_name(self) -> str:
         """
         Name of the per-format subdirectory in the output layout
-        `<output root>/<directory_name>/<patch name>/`. Defaults to
-        `format_id`; a format may override it when its conventional
+        `<output root>/<directory_name>/{Samples,Instruments}/`. Defaults
+        to `format_id`; a format may override it when its conventional
         directory name differs from the CLI identifier.
         """
         return self.format_id

--- a/src/midi_sampling/export/exceptions.py
+++ b/src/midi_sampling/export/exceptions.py
@@ -38,11 +38,3 @@ class ExportWriteError(ExportError):
     Raised when the patch file cannot be written.
     """
     pass
-
-
-class ExportExistingOutputError(ExportError):
-    """
-    Raised when the patch output directory already contains files.
-    Existing export output is never overwritten or deleted automatically.
-    """
-    pass

--- a/src/midi_sampling/export/export_executor.py
+++ b/src/midi_sampling/export/export_executor.py
@@ -7,23 +7,25 @@ from midi_sampling.export.abstractions import (
     PatchWriteContext,
 )
 from midi_sampling.export.audio import AudioExporter
-from midi_sampling.export.exceptions import (
-    ExportExistingOutputError,
-    ExportWriteError,
+from midi_sampling.export.exceptions import ExportWriteError
+from midi_sampling.export.planning import (
+    INSTRUMENTS_DIRECTORY_NAME,
+    ExportPlan,
 )
-from midi_sampling.export.planning import ExportPlan
 
 logger = getLogger(__name__)
 
 
 class ExportExecutor:
     """
-    Write the audio files and the patch file into the output directory.
+    Write the audio files and the patch file into the output root, which
+    holds `Samples/<tone-id>/` and `Instruments/<name>.<ext>` for one
+    patch format.
 
-    Read-only with respect to the recorded and processed trees, and it
-    never overwrites existing export output: a non-empty output
-    directory is refused, matching the postprocess rule for derived
-    output.
+    Read-only with respect to the recorded and processed trees. Unlike
+    sampling and postprocess, an existing output root is accepted and
+    its files are overwritten: several instruments share one root by
+    design, so exporting is repeatable and additive.
     """
 
     def __init__(
@@ -36,40 +38,62 @@ class ExportExecutor:
         self._audio_exporter = audio_exporter
         self._progress = progress if progress is not None else (lambda message: None)
 
-    def execute(self, plan: ExportPlan, output_directory: Path) -> Path:
-        output_directory = Path(output_directory)
-        if output_directory.exists() and any(output_directory.iterdir()):
-            raise ExportExistingOutputError(
-                f"{output_directory}: output directory is not empty; "
-                f"existing export output is never overwritten"
-            )
+    def execute(self, plan: ExportPlan, output_root: Path) -> Path:
+        output_root = Path(output_root)
+        patch_directory = output_root / INSTRUMENTS_DIRECTORY_NAME
 
-        try:
-            output_directory.mkdir(parents=True, exist_ok=True)
-        except OSError as e:
-            raise ExportWriteError(
-                f"{output_directory}: cannot create output directory: {e}"
-            ) from e
+        for directory in (output_root, patch_directory):
+            try:
+                directory.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                raise ExportWriteError(
+                    f"{directory}: cannot create output directory: {e}"
+                ) from e
 
         self._progress(
             f"Exporting {plan.instrument.name!r}: "
             f"{len(plan.audio_tasks)} sample(s) as {plan.audio_format}"
         )
 
+        self._warn_on_occupied_sample_directories(plan, output_root)
+
         for task in plan.audio_tasks:
             logger.debug(f"Writing {task.relative_path}")
             self._audio_exporter.export(
                 task.source_path,
-                output_directory / task.relative_path,
+                output_root / task.relative_path,
                 task.data_format,
             )
 
         outcome = self._writer.write(
             PatchWriteContext(
                 instrument=plan.instrument,
-                output_directory=output_directory,
+                patch_directory=patch_directory,
             )
         )
 
         self._progress(f"Wrote patch: {outcome.patch_path}")
         return outcome.patch_path
+
+    def _warn_on_occupied_sample_directories(
+        self, plan: ExportPlan, output_root: Path
+    ) -> None:
+        """
+        Warn once per `Samples/<tone-id>/` that already holds files.
+
+        Tone ids are the sample namespace of the whole output root, so an
+        occupied directory means this export or another instrument
+        already wrote that tone; its files are about to be replaced.
+        Warning per directory rather than per file keeps a routine
+        re-export from drowning in one line per sample.
+        """
+        seen: set[Path] = set()
+        for task in plan.audio_tasks:
+            directory = (output_root / task.relative_path).parent
+            if directory in seen:
+                continue
+            seen.add(directory)
+            if directory.exists() and any(directory.iterdir()):
+                logger.warning(
+                    f"{directory}: overwriting existing sample files"
+                )

--- a/src/midi_sampling/export/nki_impl/nki_patch_writer.py
+++ b/src/midi_sampling/export/nki_impl/nki_patch_writer.py
@@ -47,14 +47,14 @@ class NkiPatchWriter(InstrumentPatchWriter):
 
     def write(self, context: PatchWriteContext) -> PatchWriteOutcome:
         instrument = context.instrument
-        patch_path = context.output_directory / f"{instrument.name}{PATCH_SUFFIX}"
+        patch_path = context.patch_directory / f"{instrument.name}{PATCH_SUFFIX}"
 
         self._warn_ignored_rt_decay(instrument)
 
         groups, region_groups = partition_groups(instrument)
         samples: dict[str, WavDataInfo] = {
             region.sample_path: read_wav_data_info(
-                context.output_directory / region.sample_path
+                context.patch_directory / region.sample_path
             )
             for region in instrument.regions
         }

--- a/src/midi_sampling/export/planning/__init__.py
+++ b/src/midi_sampling/export/planning/__init__.py
@@ -1,7 +1,13 @@
-from .export_plan import SAMPLES_DIRECTORY_NAME, AudioExportTask, ExportPlan
+from .export_plan import (
+    INSTRUMENTS_DIRECTORY_NAME,
+    SAMPLES_DIRECTORY_NAME,
+    AudioExportTask,
+    ExportPlan,
+)
 from .export_plan_builder import ExportPlanBuilder
 
 __all__ = [
+    "INSTRUMENTS_DIRECTORY_NAME",
     "SAMPLES_DIRECTORY_NAME",
     "AudioExportTask",
     "ExportPlan",

--- a/src/midi_sampling/export/planning/export_plan.py
+++ b/src/midi_sampling/export/planning/export_plan.py
@@ -5,13 +5,20 @@ from midi_sampling.export.abstractions import InstrumentModel
 from midi_sampling.export.definitions import AudioFormat
 
 SAMPLES_DIRECTORY_NAME = "Samples"
+INSTRUMENTS_DIRECTORY_NAME = "Instruments"
+
+# Step from a patch file back up to the output root. The patch lives in
+# `<root>/<INSTRUMENTS_DIRECTORY_NAME>/`, one level below the samples
+# root, so every sample reference inside a patch is prefixed with this.
+PATCH_TO_ROOT_PREFIX = ".."
 
 
 @dataclass(frozen=True)
 class AudioExportTask:
     """
     One audio file to write into the patch output directory.
-    `relative_path` is POSIX-style, relative to the output directory.
+    `relative_path` is POSIX-style, relative to the output root (the
+    per-format directory that holds both `Samples/` and `Instruments/`).
     """
     source_path: Path
     relative_path: str

--- a/src/midi_sampling/export/planning/export_plan_builder.py
+++ b/src/midi_sampling/export/planning/export_plan_builder.py
@@ -11,6 +11,7 @@ from midi_sampling.export.abstractions import (
 from midi_sampling.export.audio import WAV_SUFFIX, AudioExporter
 from midi_sampling.export.exceptions import ExportDefinitionError
 from midi_sampling.export.planning.export_plan import (
+    PATCH_TO_ROOT_PREFIX,
     SAMPLES_DIRECTORY_NAME,
     AudioExportTask,
     ExportPlan,
@@ -58,14 +59,14 @@ class ExportPlanBuilder:
             rt_decay = release_decays.get(tone.tone_id)
 
             for sample in tone.manifest.samples:
-                relative_path = self._relative_sample_path(
+                relative_path = self._sample_output_path(
                     tone, sample, suffix
                 )
                 regions.append(
                     InstrumentRegion(
                         tone_id=tone.tone_id,
                         source_path=tone.directory / sample.file,
-                        sample_path=relative_path,
+                        sample_path=self._sample_reference_path(relative_path),
                         root_note=sample.mapping.root_note,
                         key_low=sample.mapping.key_low,
                         key_high=sample.mapping.key_high,
@@ -119,15 +120,26 @@ class ExportPlanBuilder:
         )
         return fallback
 
-    def _relative_sample_path(
+    def _sample_output_path(
         self, tone: ResolvedToneSource, sample: ManifestSample, suffix: str
     ) -> str:
+        """
+        Where the audio file is written, relative to the output root.
+        """
         stem = (
             sample.file[: -len(WAV_SUFFIX)]
             if sample.file.lower().endswith(WAV_SUFFIX)
             else sample.file
         )
         return f"{SAMPLES_DIRECTORY_NAME}/{tone.tone_id}/{stem}{suffix}"
+
+    def _sample_reference_path(self, output_path: str) -> str:
+        """
+        How a patch refers to that same file. Patches are written one
+        level below the output root, so the reference is the output path
+        seen from `<root>/Instruments/`.
+        """
+        return f"{PATCH_TO_ROOT_PREFIX}/{output_path}"
 
     def _resolve_loop(self, sample: ManifestSample) -> RegionLoop | None:
         loop = sample.loop

--- a/src/midi_sampling/export/sfz_impl/sfz_patch_writer.py
+++ b/src/midi_sampling/export/sfz_impl/sfz_patch_writer.py
@@ -30,7 +30,7 @@ class SfzPatchWriter(InstrumentPatchWriter):
 
     def write(self, context: PatchWriteContext) -> PatchWriteOutcome:
         instrument = context.instrument
-        patch_path = context.output_directory / f"{instrument.name}{PATCH_SUFFIX}"
+        patch_path = context.patch_directory / f"{instrument.name}{PATCH_SUFFIX}"
 
         content = self._render(instrument)
         try:

--- a/tests/test_export_cli.py
+++ b/tests/test_export_cli.py
@@ -31,18 +31,21 @@ class TestExportCli:
         assert result.exit_code == 0
         assert "export" in result.output
 
-    def test_exports_self_contained_sfz_patch(self, tmp_path: Path, instrument_file: Path):
+    def test_exports_sfz_patch_into_shared_format_root(
+        self, tmp_path: Path, instrument_file: Path
+    ):
         result = runner.invoke(cli.app, ["export", str(instrument_file)])
 
         assert result.exit_code == 0, result.output
-        patch_dir = tmp_path / "patches" / "sfz" / "test-instrument"
-        patch_path = patch_dir / "test-instrument.sfz"
+        format_root = tmp_path / "patches" / "sfz"
+        patch_path = format_root / "Instruments" / "test-instrument.sfz"
         assert patch_path.is_file()
-        assert len(list((patch_dir / "Samples" / "tone-1").glob("*.wav"))) == 4
+        assert len(list((format_root / "Samples" / "tone-1").glob("*.wav"))) == 4
 
         content = patch_path.read_text(encoding="utf-8")
         assert content.count("<region>") == 4
-        assert "sample=Samples/tone-1/" in content
+        # The patch sits one level below the samples root.
+        assert "sample=../Samples/tone-1/" in content
         assert "<global>" in content
         assert "ampeg_attack=0" in content
         assert "ampeg_release=0.3" in content
@@ -66,16 +69,48 @@ class TestExportCli:
         )
 
         assert result.exit_code == 0, result.output
-        # The <format>/<name> layout applies below the explicit root too.
-        assert (output / "sfz" / "test-instrument" / "test-instrument.sfz").is_file()
+        # The <format>/{Samples,Instruments} layout applies below the
+        # explicit root too.
+        assert (output / "sfz" / "Instruments" / "test-instrument.sfz").is_file()
+        assert (output / "sfz" / "Samples" / "tone-1").is_dir()
 
-    def test_existing_output_is_refused(self, tmp_path: Path, instrument_file: Path):
+    def test_re_exporting_overwrites_existing_output(
+        self, tmp_path: Path, instrument_file: Path
+    ):
         first = runner.invoke(cli.app, ["export", str(instrument_file)])
         assert first.exit_code == 0, first.output
 
         second = runner.invoke(cli.app, ["export", str(instrument_file)])
-        assert second.exit_code == 1
-        assert "never overwritten" in second.output
+        assert second.exit_code == 0, second.output
+        assert (
+            tmp_path / "patches" / "sfz" / "Instruments" / "test-instrument.sfz"
+        ).is_file()
+
+    def test_instruments_share_one_format_root(
+        self, tmp_path: Path, instrument_file: Path
+    ):
+        second_file = tmp_path / "second.yaml"
+        second_file.write_text(
+            "schema_version: 1\n"
+            "kind: instrument_definition\n"
+            "name: second-instrument\n"
+            "sources:\n"
+            "  - { tone: tone-1, manifest: processed/tone-1/manifest.yaml }\n",
+            encoding="utf-8",
+        )
+
+        for definition in (instrument_file, second_file):
+            result = runner.invoke(cli.app, ["export", str(definition)])
+            assert result.exit_code == 0, result.output
+
+        format_root = tmp_path / "patches" / "sfz"
+        assert sorted(
+            path.name for path in (format_root / "Instruments").iterdir()
+        ) == ["second-instrument.sfz", "test-instrument.sfz"]
+        # Both patches reference the same shared Samples tree.
+        assert [path.name for path in (format_root / "Samples").iterdir()] == [
+            "tone-1"
+        ]
 
     def test_unknown_format_exits_with_definition_error(
         self, tmp_path: Path, instrument_file: Path
@@ -101,7 +136,7 @@ class TestNkiExportCli:
         replace_with_real_wavs(tmp_path / "processed")
         return make_instrument_definition(tmp_path)
 
-    def test_exports_self_contained_nki_patch(
+    def test_exports_nki_patch_into_shared_format_root(
         self, tmp_path: Path, instrument_file: Path
     ):
         result = runner.invoke(
@@ -109,10 +144,10 @@ class TestNkiExportCli:
         )
 
         assert result.exit_code == 0, result.output
-        patch_dir = tmp_path / "patches" / "nki" / "test-instrument"
-        patch_path = patch_dir / "test-instrument.nki"
+        format_root = tmp_path / "patches" / "nki"
+        patch_path = format_root / "Instruments" / "test-instrument.nki"
         assert patch_path.is_file()
-        assert len(list((patch_dir / "Samples" / "tone-1").glob("*.wav"))) == 4
+        assert len(list((format_root / "Samples" / "tone-1").glob("*.wav"))) == 4
 
         import zlib
 
@@ -140,6 +175,6 @@ class TestNkiExportCli:
         )
 
         assert result.exit_code == 0, result.output
-        samples = tmp_path / "patches" / "nki" / "test-instrument" / "Samples"
+        samples = tmp_path / "patches" / "nki" / "Samples"
         assert len(list(samples.rglob("*.wav"))) == 4
         assert list(samples.rglob("*.flac")) == []

--- a/tests/test_export_executor.py
+++ b/tests/test_export_executor.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+
+from conftest import make_wav_bytes
+from midi_sampling.export.abstractions import (
+    InstrumentEnvelope,
+    InstrumentModel,
+    InstrumentPatchWriter,
+    InstrumentRegion,
+    PatchWriteContext,
+    PatchWriteOutcome,
+)
+from midi_sampling.export.audio import AudioExporter
+from midi_sampling.export.export_executor import ExportExecutor
+from midi_sampling.export.planning import AudioExportTask, ExportPlan
+
+PATCH_SUFFIX = ".fake"
+
+
+class FakePatchWriter(InstrumentPatchWriter):
+    """
+    Records the context it was handed, so the layout the executor builds
+    is observable without depending on a real patch format.
+    """
+
+    def __init__(self) -> None:
+        self.contexts: list[PatchWriteContext] = []
+
+    @property
+    def format_id(self) -> str:
+        return "fake"
+
+    def write(self, context: PatchWriteContext) -> PatchWriteOutcome:
+        self.contexts.append(context)
+        patch_path = (
+            context.patch_directory / f"{context.instrument.name}{PATCH_SUFFIX}"
+        )
+        patch_path.write_text("patch", encoding="utf-8")
+        return PatchWriteOutcome(patch_path=patch_path)
+
+
+def make_plan(
+    source: Path,
+    name: str = "test-instrument",
+    files: tuple[str, ...] = ("a.wav", "b.wav"),
+) -> ExportPlan:
+    """
+    One tone with several samples, so that warnings emitted per tone
+    directory are distinguishable from warnings emitted per file.
+    """
+    relative_paths = tuple(f"Samples/tone-1/{file}" for file in files)
+    return ExportPlan(
+        instrument=InstrumentModel(
+            name=name,
+            envelope=InstrumentEnvelope(attack=0.0, release=0.3),
+            regions=tuple(
+                InstrumentRegion(
+                    tone_id="tone-1",
+                    source_path=source,
+                    sample_path=f"../{relative_path}",
+                    root_note=38,
+                    key_low=36,
+                    key_high=40,
+                    velocity_low=1,
+                    velocity_high=127,
+                    loop=None,
+                    exclusive_group=None,
+                    trigger="attack",
+                    rt_decay=None,
+                )
+                for relative_path in relative_paths
+            ),
+            exclusive_groups=(),
+        ),
+        audio_format="wav",
+        bit_depth=None,
+        audio_tasks=tuple(
+            AudioExportTask(
+                source_path=source,
+                relative_path=relative_path,
+                data_format="int16",
+            )
+            for relative_path in relative_paths
+        ),
+    )
+
+
+def make_executor(writer: InstrumentPatchWriter) -> ExportExecutor:
+    return ExportExecutor(writer=writer, audio_exporter=AudioExporter("wav"))
+
+
+def make_source(tmp_path: Path, frames: int = 100) -> Path:
+    source = tmp_path / "source.wav"
+    source.write_bytes(make_wav_bytes(frames))
+    return source
+
+
+class TestExportExecutorLayout:
+    def test_splits_samples_and_instruments(self, tmp_path: Path):
+        source = make_source(tmp_path)
+        writer = FakePatchWriter()
+        output_root = tmp_path / "out"
+
+        patch_path = make_executor(writer).execute(make_plan(source), output_root)
+
+        assert patch_path == (
+            output_root / "Instruments" / f"test-instrument{PATCH_SUFFIX}"
+        )
+        assert (output_root / "Samples" / "tone-1" / "a.wav").is_file()
+        assert writer.contexts[0].patch_directory == output_root / "Instruments"
+
+    def test_region_paths_resolve_from_the_patch_directory(self, tmp_path: Path):
+        source = make_source(tmp_path)
+        writer = FakePatchWriter()
+        output_root = tmp_path / "out"
+
+        make_executor(writer).execute(make_plan(source), output_root)
+
+        context = writer.contexts[0]
+        region = context.instrument.regions[0]
+        assert (context.patch_directory / region.sample_path).is_file()
+
+
+class TestExportExecutorExistingOutput:
+    def test_existing_output_root_is_accepted(self, tmp_path: Path):
+        source = make_source(tmp_path)
+        output_root = tmp_path / "out"
+        (output_root / "Samples").mkdir(parents=True)
+        (output_root / "leftover.txt").write_text("keep me", encoding="utf-8")
+
+        make_executor(FakePatchWriter()).execute(make_plan(source), output_root)
+
+        assert (output_root / "Instruments").is_dir()
+        # Unrelated files are left alone; nothing is cleaned up.
+        assert (output_root / "leftover.txt").read_text(encoding="utf-8") == "keep me"
+
+    def test_re_export_overwrites_and_warns(self, tmp_path: Path, caplog):
+        source = make_source(tmp_path)
+        output_root = tmp_path / "out"
+        executor = make_executor(FakePatchWriter())
+        executor.execute(make_plan(source), output_root)
+
+        # A second instrument reusing tone-1 writes over the same sample.
+        source.write_bytes(make_wav_bytes(frames=200))
+        with caplog.at_level("WARNING"):
+            executor.execute(make_plan(source, name="second"), output_root)
+
+        # One warning for the shared tone directory, not one per file.
+        assert caplog.text.count("overwriting existing sample files") == 1
+        exported = output_root / "Samples" / "tone-1" / "a.wav"
+        assert exported.read_bytes() == source.read_bytes()
+        assert sorted(
+            path.name for path in (output_root / "Instruments").iterdir()
+        ) == [f"second{PATCH_SUFFIX}", f"test-instrument{PATCH_SUFFIX}"]
+
+    def test_first_export_does_not_warn(self, tmp_path: Path, caplog):
+        source = make_source(tmp_path)
+
+        with caplog.at_level("WARNING"):
+            make_executor(FakePatchWriter()).execute(
+                make_plan(source), tmp_path / "out"
+            )
+
+        assert "overwriting" not in caplog.text

--- a/tests/test_export_nki_writer.py
+++ b/tests/test_export_nki_writer.py
@@ -18,6 +18,7 @@ from midi_sampling.export.abstractions import (
 from midi_sampling.export.exceptions import ExportWriteError
 from midi_sampling.export.nki_impl import NkiPatchWriter
 from midi_sampling.export.nki_impl.nki_grouping import partition_groups
+from midi_sampling.export.planning import INSTRUMENTS_DIRECTORY_NAME
 from midi_sampling.export.nki_impl.wav_info import read_wav_data_info
 
 DEFAULT_ENVELOPE = InstrumentEnvelope(attack=0.0, release=0.3)
@@ -29,7 +30,7 @@ def make_region(**overrides) -> InstrumentRegion:
     values = dict(
         tone_id="tone-1",
         source_path=Path("processed/tone-1/a.wav"),
-        sample_path="Samples/tone-1/a.wav",
+        sample_path="../Samples/tone-1/a.wav",
         root_note=38,
         key_low=36,
         key_high=40,
@@ -55,20 +56,31 @@ def make_instrument(regions, exclusive_groups=(), **overrides) -> InstrumentMode
     return InstrumentModel(**values)
 
 
+def make_patch_directory(tmp_path: Path) -> Path:
+    """
+    The Instruments/ directory of an output root, so that the regions'
+    `../Samples/...` references land inside `tmp_path`.
+    """
+    patch_directory = tmp_path / INSTRUMENTS_DIRECTORY_NAME
+    patch_directory.mkdir(parents=True, exist_ok=True)
+    return patch_directory
+
+
 def write_region_wavs(
-    output_directory: Path, instrument: InstrumentModel, frames: int = 100
+    patch_directory: Path, instrument: InstrumentModel, frames: int = 100
 ) -> None:
     for region in instrument.regions:
-        path = output_directory / region.sample_path
+        path = patch_directory / region.sample_path
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(make_wav_bytes(frames))
 
 
 def write_patch(tmp_path: Path, instrument: InstrumentModel, frames: int = 100):
-    write_region_wavs(tmp_path, instrument, frames=frames)
+    patch_directory = make_patch_directory(tmp_path)
+    write_region_wavs(patch_directory, instrument, frames=frames)
     writer = NkiPatchWriter(clock=lambda: FIXED_TIME + 0.9)
     return writer.write(
-        PatchWriteContext(instrument=instrument, output_directory=tmp_path)
+        PatchWriteContext(instrument=instrument, patch_directory=patch_directory)
     )
 
 
@@ -210,14 +222,16 @@ class TestNkiPatchWriter:
             [
                 make_region(),
                 make_region(
-                    tone_id="tone-2", sample_path="Samples/tone-2/b.wav"
+                    tone_id="tone-2", sample_path="../Samples/tone-2/b.wav"
                 ),
             ]
         )
 
         outcome = write_patch(tmp_path, instrument, frames=100)
 
-        assert outcome.patch_path == tmp_path / "test-instrument.nki"
+        assert outcome.patch_path == (
+            tmp_path / INSTRUMENTS_DIRECTORY_NAME / "test-instrument.nki"
+        )
         raw = outcome.patch_path.read_bytes()
         header = struct.unpack("<4sIHH6I", raw[:0x24])
         assert header[0] == b"\x5e\xe5\x6e\xb3"
@@ -317,7 +331,7 @@ class TestNkiPatchWriter:
         assert parameters["lowVelocity"] == "1"
         assert parameters["highVelocity"] == "63"
         assert first.find("Sample/V[@name='file']").get("value") == (
-            "Samples\\tone-1\\a.wav"
+            "..\\Samples\\tone-1\\a.wav"
         )
 
         loop = first.find("Loops/Loop")
@@ -412,7 +426,7 @@ class TestNkiPatchWriter:
 
     def test_escapes_xml_attribute_values(self, tmp_path: Path):
         instrument = make_instrument(
-            [make_region(sample_path="Samples/tone-1/a&b.wav")],
+            [make_region(sample_path="../Samples/tone-1/a&b.wav")],
             name="amp&name's",
         )
 
@@ -420,7 +434,7 @@ class TestNkiPatchWriter:
         xml_text = decompress_xml(outcome.patch_path)
 
         assert 'name="amp&amp;name&apos;s"' in xml_text
-        assert 'value="Samples\\tone-1\\a&amp;b.wav"' in xml_text
+        assert 'value="..\\Samples\\tone-1\\a&amp;b.wav"' in xml_text
         program = ET.fromstring(xml_text)
         assert program.get("name") == "amp&name's"
 
@@ -442,6 +456,7 @@ class TestNkiPatchWriter:
         with pytest.raises(ExportWriteError):
             writer.write(
                 PatchWriteContext(
-                    instrument=instrument, output_directory=tmp_path
+                    instrument=instrument,
+                    patch_directory=make_patch_directory(tmp_path),
                 )
             )

--- a/tests/test_export_plan_builder.py
+++ b/tests/test_export_plan_builder.py
@@ -68,7 +68,7 @@ class TestExportPlanBuilder:
         assert plan.instrument.envelope.release == 0.3
 
         region = plan.instrument.regions[0]
-        assert region.sample_path.startswith("Samples/tone-1/")
+        assert region.sample_path.startswith("../Samples/tone-1/")
         assert region.sample_path.endswith(".wav")
         assert region.trigger == "attack"
         assert region.exclusive_group is None
@@ -85,6 +85,24 @@ class TestExportPlanBuilder:
             (41, 43, 45, 1, 63),
             (41, 43, 45, 64, 127),
         }
+
+    def test_task_and_region_paths_use_different_bases(
+        self, tmp_path: Path, processed: Path
+    ):
+        plan = build(
+            tmp_path,
+            "schema_version: 1\n"
+            "kind: instrument_definition\n"
+            "name: test-instrument\n"
+            "sources:\n"
+            "  - { tone: tone-1, manifest: processed/tone-1/manifest.yaml }\n",
+        )
+
+        # The task path is relative to the output root, the region path
+        # to the patch file one level below it in Instruments/.
+        for task, region in zip(plan.audio_tasks, plan.instrument.regions):
+            assert task.relative_path.startswith("Samples/tone-1/")
+            assert region.sample_path == f"../{task.relative_path}"
 
     def test_flac_format_changes_sample_extension(
         self, tmp_path: Path, processed: Path

--- a/tests/test_export_sfz_writer.py
+++ b/tests/test_export_sfz_writer.py
@@ -18,7 +18,7 @@ def make_region(**overrides) -> InstrumentRegion:
     values = dict(
         tone_id="tone-1",
         source_path=Path("processed/tone-1/a.wav"),
-        sample_path="Samples/tone-1/a.wav",
+        sample_path="../Samples/tone-1/a.wav",
         root_note=38,
         key_low=36,
         key_high=40,
@@ -52,7 +52,7 @@ class TestSfzPatchWriter:
                 ),
                 make_region(
                     tone_id="tone-2",
-                    sample_path="Samples/tone-2/b.flac",
+                    sample_path="../Samples/tone-2/b.flac",
                     root_note=43,
                     key_low=41,
                     key_high=45,
@@ -66,7 +66,7 @@ class TestSfzPatchWriter:
         )
 
         outcome = SfzPatchWriter().write(
-            PatchWriteContext(instrument=instrument, output_directory=tmp_path)
+            PatchWriteContext(instrument=instrument, patch_directory=tmp_path)
         )
 
         assert outcome.patch_path == tmp_path / "test-instrument.sfz"
@@ -81,13 +81,13 @@ class TestSfzPatchWriter:
             "ampeg_release=0.3",
             "",
             "// tone: tone-1",
-            "<region> sample=Samples/tone-1/a.wav"
+            "<region> sample=../Samples/tone-1/a.wav"
             " lokey=36 hikey=40 pitch_keycenter=38 lovel=1 hivel=63"
             " loop_mode=loop_continuous loop_start=1000 loop_end=2000"
             " group=1 off_by=1 off_mode=fast",
             "",
             "// tone: tone-2",
-            "<region> sample=Samples/tone-2/b.flac trigger=release rt_decay=6"
+            "<region> sample=../Samples/tone-2/b.flac trigger=release rt_decay=6"
             " lokey=41 hikey=45 pitch_keycenter=43 lovel=64 hivel=127"
             " loop_mode=no_loop",
         ]
@@ -101,7 +101,7 @@ class TestSfzPatchWriter:
         )
 
         outcome = SfzPatchWriter().write(
-            PatchWriteContext(instrument=instrument, output_directory=tmp_path)
+            PatchWriteContext(instrument=instrument, patch_directory=tmp_path)
         )
 
         content = outcome.patch_path.read_text(encoding="utf-8")
@@ -117,7 +117,7 @@ class TestSfzPatchWriter:
         )
 
         outcome = SfzPatchWriter().write(
-            PatchWriteContext(instrument=instrument, output_directory=tmp_path)
+            PatchWriteContext(instrument=instrument, patch_directory=tmp_path)
         )
 
         raw = outcome.patch_path.read_bytes()


### PR DESCRIPTION
… instruments

- Updated export implementation to allow overwriting existing output in shared format root.
- Changed output layout to separate Samples and Instruments directories under format root.
- Modified patch writers to reference audio files correctly based on new directory structure.
- Adjusted CLI help messages and documentation to reflect changes in output paths.
- Enhanced tests to verify correct behavior with shared output and overwriting logic.